### PR TITLE
Documentation audit: 11 new/expanded help files + analytics reference + bug fixes

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -48,7 +48,9 @@ Combination creation (2 or 3 disciplines in one session, single Onboarding intak
   Examples: CREATE TECH UX project · CREATE BUSINESS MARKETING project · CREATE TECH UX MARKETING project
 
 Orchestrator
-  ↓ [required: Onboarding Output COMPLETE including session-state.json]
+  ↓ [On command: IMMEDIATELY creates session-state.json with status: ONBOARDING per ORC-46]
+  ↓ [Activates Onboarding Agent]
+  ↓ [required: Onboarding Output COMPLETE; session-state.json updated to ONBOARDING_COMPLETE]
   ↓ [Questionnaire Agent: load existing answers from BusinessDocs/ → inject into phase-agent contexts]
 Phase 1 — Requirements & Strategy: Business Analyst → Domain Expert → Sales Strategist → Financial Analyst → Product Manager (34)
   ↓ [CRITIC + RISK validation]

--- a/.github/docs/analytics-events.json
+++ b/.github/docs/analytics-events.json
@@ -1,0 +1,23 @@
+[
+  {
+    "event": "tab_switch",
+    "properties": {
+      "tab": "questionnaires"
+    },
+    "timestamp": "2026-03-08T18:21:44.881Z"
+  },
+  {
+    "event": "tab_switch",
+    "properties": {
+      "tab": "decisions"
+    },
+    "timestamp": "2026-03-08T18:21:44.881Z"
+  },
+  {
+    "event": "tab_switch",
+    "properties": {
+      "tab": "commandcenter"
+    },
+    "timestamp": "2026-03-08T18:21:44.881Z"
+  }
+]

--- a/.github/docs/audit/audit-log.jsonl
+++ b/.github/docs/audit/audit-log.jsonl
@@ -323,3 +323,4 @@
 {"timestamp":"2026-03-08T14:09:02.606Z","operation":"update","entity_type":"analytics-events","entity_id":null,"user":"system","summary":"File written: .github/docs/analytics-events.json"}
 {"timestamp":"2026-03-08T14:09:02.618Z","operation":"update","entity_type":"command-queue","entity_id":null,"user":"system","summary":"File written: .github/docs/session/command-queue.json"}
 {"timestamp":"2026-03-08T14:09:02.619Z","operation":"update","entity_type":"command-queue","entity_id":null,"user":"system","summary":"File written: .github/docs/session/command-queue.json"}
+{"timestamp":"2026-03-08T18:21:44.883Z","operation":"update","entity_type":"analytics-events","entity_id":null,"user":"system","summary":"File written: .github/docs/analytics-events.json"}

--- a/.github/docs/contracts/session-state-contract.md
+++ b/.github/docs/contracts/session-state-contract.md
@@ -17,7 +17,7 @@ This contract defines:
 ## SESSION STATE FILE
 
 **Location:** `.github/docs/session/session-state.json`
-**Owner:** Only the Orchestrator writes to this file. Other agents submit state updates **to** the Orchestrator via their HANDOFF CHECKLIST.
+**Owner:** Only the Orchestrator writes to this file. The Orchestrator **creates** this file immediately upon receiving a command (per ORC-46 in `.github/skills/00-orchestrator.md`) with `status: "ONBOARDING"`. The Onboarding Agent **updates** it to `status: "ONBOARDING_COMPLETE"` at the end of onboarding. Other agents submit state updates **to** the Orchestrator via their HANDOFF CHECKLIST.
 
 ---
 
@@ -243,7 +243,9 @@ This file is a separate signal file (same pattern as `reevaluate-trigger.json`).
 
 ```
 ONBOARDING
-  → PHASE-1          (after ONBOARDING_COMPLETE)
+  → ONBOARDING_COMPLETE  (Onboarding Agent updates session-state; internal transition)
+ONBOARDING_COMPLETE
+  → PHASE-1          (Orchestrator advances after ONBOARDING_COMPLETE)
 PHASE-1
   → PHASE-2          (after Critic + Risk PASSED)
 PHASE-2

--- a/.github/help/advanced-commands.md
+++ b/.github/help/advanced-commands.md
@@ -1,0 +1,209 @@
+# Advanced Commands — FEATURE, SCOPE CHANGE & HOTFIX
+
+The [Commands Reference](commands.md) lists every command. This page goes deeper into the three on-demand commands that operate **outside** the normal phase cycle: FEATURE, SCOPE CHANGE, and HOTFIX.
+
+---
+
+## FEATURE — Add a New Feature
+
+```
+FEATURE [name]: [description]
+```
+
+Use this when you want to add a new feature to an existing application that has already completed the main design cycle (Phases 1–4 + Synthesis).
+
+### What Happens
+
+1. **Intake** — The Feature Agent parses your description and produces a Feature Request Document (`Workitems/[FEATURENAME]/00-feature-request.md`). If the description is too vague (fewer than 2 concrete behavioral expectations), the system asks for clarification.
+
+2. **Full mini-cycle** — All 20 domain agents analyze the feature from their perspective, in the same Phase 1 → 2 → 3 → 4 order as the main cycle. Each phase gets its own Critic + Risk validation.
+
+3. **Synthesis** — A feature-specific synthesis report is produced with cross-domain findings, integration risks, KPI targets, and feature-specific guardrails.
+
+4. **Sprint Plan** — Stories are generated with IDs like `FT-[FEATURENAME]-S1-001`. These have their own Sprint Gate, independent from the main sprint cycle.
+
+5. **Implementation** — Each sprint follows the same Implementation → Test → PR/Review → KPI → Documentation → GitHub flow.
+
+### Isolated Workspace
+
+Everything lives in `Workitems/[FEATURENAME]/`:
+
+```
+Workitems/
+  [FEATURENAME]/
+    00-feature-request.md
+    phase-1/
+    phase-2/
+    phase-3/
+    phase-4/
+    synthesis/
+    sprintplan/
+    implementation/
+```
+
+No feature agent writes outside this directory. The existing project is used as read-only context.
+
+### Good Feature Descriptions
+
+| Quality | Example |
+|---------|---------|
+| Too vague | `FEATURE dark-mode: add dark mode` |
+| Good | `FEATURE dark-mode: Add a dark mode toggle to the settings page that persists the user's preference in localStorage, applies a dark color scheme across all pages, and respects the OS-level prefers-color-scheme setting` |
+
+The more specific you are about **who benefits**, **what the behavior should be**, and **what constraints apply**, the better the agents can analyze the feature.
+
+### When to Use FEATURE vs a Regular Sprint Story
+
+| Situation | Use |
+|-----------|-----|
+| New capability that touches business, tech, UX, and marketing | `FEATURE` |
+| Bug fix or small improvement within an existing component | Regular sprint story |
+| Adding a page that requires new data models, API endpoints, and UI | `FEATURE` |
+| Changing the text on a button | Regular sprint story |
+
+---
+
+## SCOPE CHANGE — Change Project Direction
+
+```
+SCOPE CHANGE [DIMENSION]: [description]
+```
+
+Use this when the **fundamental premise** of your project has changed — not just a detail, but the direction itself.
+
+### When SCOPE CHANGE is Appropriate
+
+| Appropriate (SCOPE CHANGE) | Not appropriate (use REEVALUATE instead) |
+|----------------------------|------------------------------------------|
+| Business model pivot: B2C → B2B | New dependency was added |
+| Architecture change: monolith → microservices | Code evolved, some findings are outdated |
+| Target audience change: consumer → enterprise | A finding was resolved or a new risk appeared |
+| Revenue model change: subscription → marketplace | Infrastructure was updated |
+| Core module replaced entirely | A bug was found and fixed |
+
+### DIMENSION Values
+
+| Dimension | What Gets Re-Analyzed |
+|-----------|----------------------|
+| `BUSINESS` | Phase 1 agents: Business Analyst, Domain Expert, Sales Strategist, Financial Analyst, Product Manager |
+| `TECH` | Phase 2 agents: Software Architect, Senior Developer, DevOps Engineer, Security Architect, Data Architect, Legal Counsel |
+| `UX` | Phase 3 agents: UX Researcher, UX Designer, UI Designer, Accessibility Specialist, Content Strategist, Localization Specialist |
+| `MARKETING` | Phase 4 agents: Brand Strategist, Growth Marketer, CRO Specialist + Brand Assets + Storybook |
+| `ALL` | All agents across all 4 phases |
+
+### What Happens
+
+1. **Intake** — The Scope Change Agent asks you to clarify the old premise vs. the new premise if your description is ambiguous.
+
+2. **Backlog Hold** — All sprint tickets whose source findings are affected get status `SCOPE_CHANGE_HOLD`. Nothing is deleted — holds are reversible. Already completed tickets are tagged `SC-[N]_COMPLETED_UNREVIEWED` (informational only, not rolled back).
+
+3. **Invalidation Marking** — Affected sections in existing phase outputs get a visible warning header (`SCOPE_CHANGE_INVALIDATED` or `SCOPE_CHANGE_PARTIALLY_VALID`). Original content is preserved underneath.
+
+4. **Re-Analysis** — Only the affected dimension's agents run. They receive the new premise as primary input and are forbidden from inheriting conclusions from invalidated sections. Every re-analysis output must start with a `## Scope Change Impact` section.
+
+5. **Critic + Risk** — The re-analysis goes through quality gates with additional scope-change-specific checks.
+
+6. **Delta Report** — A scope change report is produced at `.github/docs/synthesis/scope-change-[N].md` with invalidated findings, new findings, sprint reconciliation, and updated guardrails.
+
+7. **Sprint Reconciliation** — Held tickets are either REQUEUED (still valid), SUPERSEDED (replaced by new work), or CANCELLED. The Sprint Gate enforces this before any sprint resumes.
+
+8. **Official Documents** — Documents that need updating are flagged as `REQUIRED_BEFORE_SPRINT`. The Questionnaire Agent updates them before held sprints are released.
+
+### Good Scope Change Descriptions
+
+| Quality | Example |
+|---------|---------|
+| Too vague | `SCOPE CHANGE BUSINESS: we're changing direction` |
+| Good | `SCOPE CHANGE BUSINESS: Pivoting from B2C subscription model to B2B enterprise licensing. Previous assumption was individual consumers paying monthly; new model is annual contracts with IT procurement departments. Pricing, onboarding flow, and support model all change.` |
+
+Always state: **old assumption → new assumption → why**.
+
+---
+
+## HOTFIX — Emergency Production Fix
+
+```
+HOTFIX [description]
+```
+
+Use this for **critical production issues only** — things that are actively breaking the application or exposing security vulnerabilities.
+
+### Criticality Thresholds
+
+A HOTFIX is appropriate when:
+- **Security vulnerability** is actively exploitable
+- **Data loss or corruption** is occurring
+- **Application is down** or critical functionality is broken
+- **Compliance deadline** is being missed
+
+A HOTFIX will be **rejected** if:
+- It's a feature request or enhancement
+- It's a non-blocking bug that can wait for the next sprint
+- It's a performance issue that doesn't affect availability
+
+If rejected, you'll see: `⚠️ HOTFIX REJECTED — [description] does not meet criticality thresholds. Use a regular sprint story instead.`
+
+### What Happens
+
+```
+HOTFIX [description]
+  → Orchestrator validates criticality
+  → Sprint Gate BYPASS (Definition of Ready skipped)
+  → Implementation Agent (hotfix scope only)
+  → Test Agent (abbreviated: repaired functionality + 1-layer regression)
+  → PR/Review Agent (secret scan mandatory)
+  → Merge
+  → KPI Agent + Documentation Agent + GitHub Integration Agent
+  → Retrospective Agent
+  → LESSON_CANDIDATE auto-generated
+```
+
+Key differences from a normal sprint:
+- **Sprint Gate is bypassed** — no Definition of Ready check
+- **Testing is abbreviated** — only the repaired functionality plus one layer of related modules
+- **Sprint ID** uses `HOTFIX-[N]` format (numbered separately)
+- **A LESSON_CANDIDATE is always generated** — every hotfix produces a learning entry
+- If the hotfix implies a structural constraint, a `DECIDED` item is added to `.github/docs/decisions.md`
+
+### Concurrency with Active Sprints
+
+If a regular sprint is running when a HOTFIX is triggered:
+- The sprint is **not paused** unless the hotfix touches overlapping files
+- Overlapping `IN_PROGRESS` stories move to `BLOCKED` with reason `HOTFIX_OVERLAP: HOTFIX-[N]`
+- After the hotfix merges, tests re-run for all blocked stories
+- Hotfix PRs always have merge priority over regular sprint PRs
+
+---
+
+## Choosing the Right Command
+
+| Situation | Command |
+|-----------|---------|
+| Adding a significant new feature | `FEATURE [name]: [description]` |
+| Project direction fundamentally changed | `SCOPE CHANGE [DIMENSION]: [description]` |
+| Critical production issue | `HOTFIX [description]` |
+| Code evolved, findings are outdated | `REEVALUATE [scope]` |
+| Need to re-scan workspace and tooling | `REFRESH ONBOARDING` |
+| Resume after an interruption | `CONTINUE` |
+
+---
+
+## Interaction Between Advanced Commands
+
+### FEATURE + SCOPE CHANGE
+If a scope change invalidates an in-progress feature, the feature's held tickets follow the same `SCOPE_CHANGE_HOLD` process. The feature must re-evaluate against the new premise before resuming.
+
+### HOTFIX + SCOPE CHANGE
+A hotfix can run during a scope change cycle. The hotfix takes priority — scope change re-analysis pauses if there's file overlap and resumes after the hotfix merges.
+
+### HOTFIX + Active Sprint
+Hotfix PRs always take merge priority. Overlapping stories are blocked until the hotfix is merged and regression tests pass.
+
+---
+
+## See Also
+
+- [Commands Reference](commands.md) — full command list with syntax
+- [Sprints](sprints.md) — how regular Sprint Gate and sprint cycles work
+- [Quality Gates](quality-gates.md) — Critic + Risk validation during FEATURE and SCOPE CHANGE
+- [Troubleshooting](troubleshooting.md) — what to do when commands fail or sessions stall

--- a/.github/help/decisions.md
+++ b/.github/help/decisions.md
@@ -1,45 +1,146 @@
-# Decisions
+# Decisions — Complete Guide
 
 ## What are decisions?
 
-Decisions are explicit records of choices made during the project. They're tracked in `.github/docs/decisions.md` and picked up by the Orchestrator at each Sprint Gate.
+Decisions are the single source of truth for every explicit choice that governs how the agentic team builds your software. They live in `.github/docs/decisions.md` (the **index file**) and in per-technology **category files** under `.github/docs/decisions/`. Every agent — from the Implementation Agent writing code to the PR/Review Agent approving merges — reads these decisions and treats `DECIDED` items as **hard constraints**.
 
-There are two types:
-- **DECIDED** — A decision you've already made (e.g. "Use PostgreSQL for the database")
-- **OPEN QUESTION** — Something that needs input from the agentic team
+There are two entry types you can create:
 
-## Status lifecycle
+- **DECIDED** — A choice you have already made (e.g. "Use PostgreSQL for the database"). The agents will enforce it immediately.
+- **OPEN QUESTION** — Something you want the agentic team to answer or that requires your input before a sprint can proceed.
 
-| Status | Meaning |
-|--------|---------|
-| `OPEN` | Awaiting a decision or answer |
-| `DECIDED` | Decision has been made and recorded |
-| `DEFERRED` | Postponed for later consideration |
-| `EXPIRED` | Deadline passed without resolution |
+---
+
+## Decision lifecycle
+
+### Statuses
+
+| Status | Meaning | Orchestrator behavior |
+|--------|---------|----------------------|
+| `OPEN` | Awaiting a decision or answer | **HIGH** priority + sprint scope match → blocks Sprint Gate. **MEDIUM/LOW** → reported but non-blocking. |
+| `DECIDED` | Decision has been made and recorded | Injected as a hard constraint into every relevant agent at sprint start. |
+| `DEFERRED` | Postponed for later | Ignored by the Orchestrator until the technology is actually needed (see *Deferred categories* below). |
+| `EXPIRED` | Deadline passed without resolution | Ignored entirely. |
+
+### Typical flow
+
+```
+You create an item (DECIDED or OPEN)
+  ↓
+OPEN items are presented at the next Sprint Gate
+  ↓  answer it → status becomes DECIDED
+  ↓  postpone → status becomes DEFERRED
+DECIDED items become hard constraints for all agents
+```
+
+### Immutability rule
+
+Once a decision is `DECIDED`, agents treat it as law. To change it:
+1. Edit the decision text via the web UI or the markdown file.
+2. The changed decision takes effect at the **next Sprint Gate** — code already merged under the old decision is not retroactively changed.
+3. If you want to undo a decision entirely, set its status to `DEFERRED` or remove it.
+
+---
 
 ## Priority levels
 
-- **HIGH** — Blocking or critical; affects sprint execution
-- **MEDIUM** — Important but not immediately blocking
-- **LOW** — Nice-to-have or informational
+| Priority | Impact |
+|----------|--------|
+| **HIGH** | Can block a Sprint Gate. If `OPEN`, the sprint cannot start until you answer. |
+| **MEDIUM** | Reported to you at the Sprint Gate but does not block progress. |
+| **LOW** | Informational. Listed but never blocks. |
 
-## Blocking decisions
+Blocking decisions have a **pulsing red badge** and a **red left border** in the web UI.
 
-Decisions marked as `BLOCKING` have a pulsing red badge and a red left border. These require urgent attention because they can block sprint progress.
+---
 
-## How to manage decisions
+## Decision categories (technology stacks)
+
+Decided items are organized by technology into separate files under `.github/docs/decisions/`. Each file has a header that includes its **Status**:
+
+| Category status | Meaning |
+|-----------------|---------|
+| **ACTIVE** | All decisions in this file are enforced as hard constraints. |
+| **PARTIAL** | Most decisions are enforced; some individual rows are marked `DEFERRED` within the file. |
+| **DEFERRED** | The entire category is inactive. Agents skip the file completely until the technology is needed. |
+
+### Which categories exist?
+
+The **Category Registry** table in `.github/docs/decisions.md` lists all categories with their file, decision count, and status. Categories cover stacks like Transformation, GitHub Actions, TypeScript/ESLint, Cross-cutting, Bicep/IaC, Azure DevOps, .NET, Docker, Vite, and NextJS (among others as the project evolves).
+
+### Deferred categories — automatic activation
+
+Deferred categories are **not ignored forever**. When any agent detects that the codebase now requires a deferred technology (e.g. a story needs Docker), the following happens automatically:
+
+1. The agent reports `DEFERRED_TECH_REQUIRED` or `DEFERRED_TECH_DETECTED` to the Orchestrator.
+2. The Orchestrator **auto-activates** the category (changes `DEFERRED` → `ACTIVE` in both the category file header and the index table) — **no user action required**.
+3. All `DECIDED` items in that category become hard constraints immediately.
+4. An audit trail line is appended to the category file with the activation date and trigger.
+5. You receive an informational notice: `ℹ️ AUTO-ACTIVATED DEFERRED CATEGORY — [stack name]`.
+
+**To revert an auto-activation:** change the Status back to `DEFERRED` in the category file header via the web UI or a manual edit. To introduce the technology *without* activating its decisions, type `SKIP ACTIVATION [category]` — the Orchestrator records an exception decision.
+
+### Why are some categories deferred?
+
+During Phases 1–4, the agentic team pre-defines decisions for technologies the project *may* need. If the technology isn't used initially, the category stays `DEFERRED` so it doesn't clutter the active constraint set. The moment the technology becomes relevant in Phase 5 (implementation), the category activates on demand.
+
+---
+
+## Sprint Gate interaction
+
+At every Sprint Gate the Orchestrator:
+
+1. **Reads** all `OPEN` + `HIGH` items whose scope matches the upcoming sprint → **blocks** the gate until you answer them.
+2. **Lists** `OPEN` + `MEDIUM`/`LOW` items as informational (non-blocking).
+3. **Loads** all `DECIDED` items from the index file and all ACTIVE/PARTIAL category files → stores them as **sprint constraints**.
+4. **Skips** DEFERRED category files entirely.
+5. **Injects** the loaded constraints into every relevant agent's context at sprint start.
+
+### What happens if I don't answer?
+
+- A `HIGH` + `OPEN` decision matching the sprint scope **will not let the sprint start**. You must answer or defer it.
+- `MEDIUM`/`LOW` decisions are reported once and do not block.
+
+---
+
+## Enforcement during implementation
+
+Decisions are enforced at **three checkpoints** in Phase 5 (the "triple-check"):
+
+| Checkpoint | Agent | What it does |
+|-----------|-------|--------------|
+| 1. Before coding | **Implementation Agent** | Loads all `DECIDED` items as hard constraints. Halts if a story requires deferred technology. |
+| 2. During testing | **Test Agent** | Validates that the code is consistent with every applicable decision. Returns violations to the Implementation Agent. |
+| 3. At PR review | **PR/Review Agent** | Re-checks decision compliance on the diff. Blocks merge on any violation. Also scans for deferred technology markers. |
+
+A violation at any checkpoint produces a `DEC-VIOLATION: [DEC-ID]` entry and the work is returned for remediation before it can proceed.
+
+---
+
+## Relationship to questionnaires
+
+Decisions and questionnaires are complementary:
+
+- **Questionnaires** are generated by the Questionnaire Agent when agents encounter `INSUFFICIENT_DATA:` items. They ask *you* for information.
+- **Decisions** are choices you make proactively (or in response to a question). Once answered, they become constraints.
+
+When a questionnaire answer resolves an open decision, the decision is updated to `DECIDED` with a cross-reference (`↔ Q-TECH-001`). The purple badge in the web UI indicates this link.
+
+---
+
+## How to manage decisions in the web UI
 
 ### Creating a decision
-1. Click **New Decision** in the header
-2. Choose type (DECIDED or OPEN QUESTION)
-3. Set priority and scope
-4. Enter the decision text and optional notes
-5. Click **Create**
+1. Click **New Decision** in the header.
+2. Choose type: `DECIDED` or `OPEN QUESTION`.
+3. Set priority (`HIGH`, `MEDIUM`, `LOW`) and scope (e.g. `Phase 2`, `SP-3`, `All sprints`).
+4. Enter the decision text and optional notes.
+5. Click **Create**.
 
 ### Answering an open question
-1. Find the open decision card
-2. Type your answer in the answer field
-3. Click **Decide** to mark it as DECIDED
+1. Find the open decision card.
+2. Type your answer in the answer field.
+3. Click **Decide** to convert it to `DECIDED`.
 
 ### Editing a decision
 Click the **Edit** button on any decision card to modify its priority, scope, text, or notes.
@@ -47,6 +148,26 @@ Click the **Edit** button on any decision card to modify its priority, scope, te
 ### Filtering decisions
 Use the filter bar at the top of the Decisions tab to search by text, priority, or status.
 
-## Cross-references
+### Activating a deferred category manually
+In the Category Registry section of the Decisions tab, click the **Activate** button next to a deferred category. This changes its status to `ACTIVE` immediately.
 
-Some decisions reference questionnaire items (shown as a purple badge like `↔ Q-TECH-001`). This links the decision to a specific questionnaire question.
+---
+
+## When should you create decisions proactively?
+
+You don't have to wait for the system to ask. Good moments to add decisions:
+
+- **Before Phase 2 starts** — technology preferences, cloud provider choices, language constraints.
+- **Before any Sprint Gate** — if you know a sprint will require a specific approach.
+- **When you disagree with a recommendation** — override it with a `DECIDED` item and the agents will comply.
+- **After a retrospective** — capture "from now on we always do X" as a permanent decision.
+
+---
+
+## File locations
+
+| What | Path |
+|------|------|
+| Decision index (open questions + category registry) | `.github/docs/decisions.md` |
+| Category files (per technology stack) | `.github/docs/decisions/*.md` |
+| Technical architecture reference | `docs/decisions-architecture.md` |

--- a/.github/help/glossary.md
+++ b/.github/help/glossary.md
@@ -1,0 +1,268 @@
+# Glossary
+
+Quick reference for terms, flags, statuses, and concepts used throughout the system.
+
+---
+
+## A
+
+**Accessibility Specialist** (Agent 13) — Phase 3 agent defining WCAG compliance standards and producing an accessibility testing plan.
+
+**ACTIVE** (Decision Category Status) — A decision category whose rules are enforced by all agents immediately. See [Decisions](decisions.md).
+
+**ADVISORY** (Dependency Type) — Non-blocking cross-team dependency. Coordination is helpful but not required for a team to proceed. Opposite of BLOCKING.
+
+**Analysis** (Deliverable Type) — First output type from phase agents. Must contain minimum 5 sourced findings, identified gaps, scored risks, and a KPI baseline.
+
+**Anti-Hallucination Protocol** — Mandatory rule requiring agents to never assert unverifiable facts, prefix uncertain claims with `UNCERTAIN:`, mark gaps as `INSUFFICIENT_DATA:`, never fabricate metrics, and always cite sources.
+
+**Anti-Laziness Protocol** — Mandatory rule requiring agents to deliver complete deliverables (no summaries or partials), never skip steps, and produce concrete findings rather than generic statements.
+
+**APPROVED** (Critic Verdict) — Output passed all quality checks. Phase can proceed.
+
+**AUDIT** (System Mode) — Alternative to CREATE mode. Analyzes existing software instead of designing new solutions, using the same four-phase structure. Command: `AUDIT [project]`.
+
+**AUTO-ACTIVATE** — Mechanism where a deferred decision category automatically becomes ACTIVE when an agent detects the technology in the codebase.
+
+## B
+
+**Backlog** (Sprint Status / Board Column) — Sprint stories queued for future implementation. Not yet selected for a Sprint Gate.
+
+**BLOCKED** (Story Status / Board Column) — A story cannot proceed due to unresolved dependencies, missing decisions, or external blockers.
+
+**BLOCKING** (Dependency Type) — Critical cross-team dependency. A team cannot start without this from another team. Must appear as BLOCKED in the sprint plan. Opposite of ADVISORY.
+
+**Brand & Assets Agent** (Agent 30) — Post-Phase 4 agent that converts brand strategy into digital assets (brand guidelines, design tokens, Canva assets). See [Synthesis](synthesis.md#brand--assets-agent).
+
+**Brand Strategist** (Agent 14) — Phase 4 agent creating brand identity, positioning, and visual direction.
+
+**Business Analyst** (Agent 01) — Phase 1 agent performing market analysis and requirements definition.
+
+## C
+
+**Canva Integration** — Optional API integration for generating visual brand assets. Status `SKIPPED_NO_TOKEN` if no token was provided during onboarding.
+
+**Checkpoint-and-Yield** — Design pattern where one agent runs per conversation turn, writes output to disk, and the Orchestrator prompts you to type CONTINUE before the next agent starts.
+
+**COMPLETED** (Story Status) — Story has been implemented, tested, reviewed, and merged. The linked GitHub issue is closed.
+
+**Content Strategist** (Agent 32) — Phase 3 agent defining content model, voice & tone guidelines, and UX writing standards.
+
+**CONTINUE** (Command) — Resume an active session from where it left off. Works with session-state.json to maintain state across conversations.
+
+**Contract Compliance** — Critic Agent check ensuring agent output matches the predefined output contracts (Analysis, Recommendations, Sprint Plan, Guardrails).
+
+**CREATE** (System Mode) — Primary mode. Designs and builds a new software solution through four phases. Command: `CREATE [project]`.
+
+**Critic Agent** (Agent 18) — Quality guardian that validates phase output for contract compliance, anti-hallucination, internal consistency, completeness, and decision register compliance. See [Quality Gates](quality-gates.md).
+
+**CRITIC_DECISION_CONFLICT** (Flag) — Recommendation contradicts a DECIDED item. Raised by Critic Agent.
+
+**CRITIC_REVIEW_SUSPICIOUS** (Flag) — Critic returned PASSED with zero findings despite open UNCERTAIN/INSUFFICIENT_DATA items. Orchestrator requires justification.
+
+**CRO Specialist** (Agent 16) — Phase 4 agent designing conversion funnels and optimizing user paths.
+
+**Cross-Team Blocker Matrix** — Synthesis document mapping BLOCKING and ADVISORY dependencies between teams. See [Synthesis](synthesis.md#cross-team-blocker-matrix).
+
+## D
+
+**Data Architect** (Agent 09) — Phase 2 agent designing data models, schemas, and pipelines.
+
+**DECIDED** (Decision Status) — A choice has been made and recorded. Becomes a hard constraint enforced by all agents at three checkpoints: before coding, during testing, at PR review. See [Decisions](decisions.md).
+
+**Decision Register** — Collection of decisions in `.github/docs/decisions.md` plus category files under `.github/docs/decisions/`.
+
+**DEFERRED** (Decision Status) — Decision postponed until the technology is actually needed. Deferred categories are ignored by agents until auto-activated.
+
+**Definition of Ready** — Checklist a story must pass before entering implementation. CODE/INFRA stories need ≥ 2 acceptance criteria and ≤ 8 story points; other types need ≥ 1 criterion. See [Sprints](sprints.md#definition-of-ready).
+
+**Delta Scan** — First step of the Reevaluate Agent. Compares current state to previous analysis and classifies findings as NEW, RESOLVED, CHANGED, or UNCHANGED.
+
+**Department Report** — Self-contained synthesis report per discipline (Business, Technology, UX, Marketing) with 8 standard sections. See [Synthesis](synthesis.md#department-reports).
+
+**Design Tokens** — Machine-readable design system definitions (colors, typography, spacing) in `.github/docs/brand/design-tokens.json`. Converted to CSS/JS by the Storybook Agent.
+
+**DevOps Engineer** (Agent 07) — Phase 2 agent designing CI/CD pipelines and deployment strategies.
+
+**Documentation Agent** (Agent 26) — Updates user manual, technical manual, and changelog after sprint implementation.
+
+**Domain Expert** (Agent 02) — Phase 1 agent providing industry-specific knowledge and domain validation.
+
+## E–F
+
+**EXPIRED** (Decision Status) — Deadline passed without resolution. Ignored by Orchestrator and agents.
+
+**FEATURE** (Command) — Adds a new feature via a full mini-cycle in an isolated workspace under `Workitems/[FEATURENAME]/`. Command: `FEATURE [name]: [description]`. See [Advanced Commands](advanced-commands.md#feature--add-a-new-feature).
+
+**Feature Agent** (Agent 24) — Coordinates independent feature development cycles from analysis through implementation.
+
+**Financial Analyst** (Agent 04) — Phase 1 agent creating revenue models and financial projections.
+
+## G
+
+**GitHub Integration Agent** (Agent 27) — Manages the GitHub project board: publishes issues, updates labels, closes completed issues, maintains board columns.
+
+**Growth Marketer** (Agent 15) — Phase 4 agent identifying growth channels and acquisition strategies.
+
+**Guardrails** (Deliverable Type) — Fourth output type from phase agents. Testable rules/constraints with explicit violation response actions.
+
+## H
+
+**HALLUCINATION_FLAG** (Flag) — Numbers, percentages, or KPIs cited without a verifiable source. Raised by Critic Agent.
+
+**Handoff Checklist** — 9-point verification checklist every agent must complete before yielding control.
+
+**HOTFIX** (Command) — Emergency fix for critical production issues. Bypasses Sprint Gate, requires abbreviated testing. Command: `HOTFIX [description]`. See [Advanced Commands](advanced-commands.md#hotfix--emergency-production-fix).
+
+## I
+
+**Implementation Agent** (Agent 20) — Writes production code per sprint stories. First checkpoint for decision enforcement.
+
+**INCOMPLETE** (Flag) — Mandatory section missing or contains only placeholder content. Raised by Critic Agent.
+
+**INCONSISTENCY_FLAG** (Flag) — An `UNCERTAIN:` claim later repeated as established fact. Raised by Critic Agent.
+
+**INSUFFICIENT_DATA:** (Prefix) — Required information that cannot be filled from available input. Triggers the Questionnaire Agent to generate questions for you.
+
+**IN_PROGRESS** (Sprint Status) — Sprint is actively being implemented.
+
+## K–L
+
+**KPI Agent** (Agent 29) — Measures sprint metrics (velocity, defect rate, code coverage, cycle time) and writes sprint KPI reports.
+
+**Legal Counsel** (Agent 33) — Phase 2 agent ensuring regulatory compliance (GDPR, licensing, privacy).
+
+**LESSON_CANDIDATE** — Learning entry auto-generated after every hotfix and available for retrospective review.
+
+**Lessons-Learned Injection** — Sprint Gate process where the Orchestrator loads top-3 lessons from previous sprints and adjusts estimates based on actual velocity.
+
+**Localization Specialist** (Agent 35) — Phase 3 agent creating the internationalization (i18n) plan and locale support matrix.
+
+## M–O
+
+**Master Report** — Executive-level synthesis document with Executive Summary, Heatmap, Risk Matrix, Roadmap, Guardrails, KPIs, and Open Items. See [Synthesis](synthesis.md#the-master-report).
+
+**Memory Management Protocol** — Mandatory rule preventing memory overload: write deliverables to disk (not chat), use targeted file reads, split outputs > 400 lines, start fresh conversations at phase boundaries.
+
+**NEEDS_REVISION** (Critic Verdict) — Output failed one or more checks. Agent receives specific remediation instructions. Maximum 3 revision cycles per phase.
+
+**NEEDS_REVIEW** (Risk Assessment Verdict) — One or more HIGH risks present in phase output. Mitigation required before proceeding.
+
+**Onboarding Agent** (Agent 25) — Conducts project intake, scans workspace/tooling, and produces the onboarding output. See [Onboarding](onboarding.md).
+
+**OPEN** (Decision Status) — Unanswered question or unresolved choice. HIGH-priority OPEN items matching sprint scope block the Sprint Gate.
+
+**Orchestrator** (Agent 00) — Master coordinator managing phase sequencing, rule enforcement, session state, quality gates, and control flow.
+
+**OUT_OF_SCOPE** — Prefix for findings outside an agent's domain. Passed to Orchestrator without recommendation.
+
+## P
+
+**PARTIAL_RUN** — Synthesis mode when not all 4 phases are complete. Only available department reports are produced; Master Report and Blocker Matrix are withheld.
+
+**Phase 1 — Requirements & Strategy** — First design phase (5 agents): business model, requirements, strategy, financial analysis.
+
+**Phase 2 — Architecture & Design** — Second design phase (6 agents): system architecture, security, data model, compliance.
+
+**Phase 3 — Experience Design** — Third design phase (6 agents): UX/UI design, content strategy, accessibility, i18n.
+
+**Phase 4 — Brand & Growth** — Fourth design phase (3 agents + Brand & Assets + Storybook): brand identity, go-to-market, conversion design.
+
+**Phase 5 — Implementation** — Sprint-based execution phase. Repeatable cycle per sprint. See [Sprints](sprints.md).
+
+**Phase Boundary** — Break point after each design phase. Triggers a fresh Copilot Chat conversation to avoid memory overload.
+
+**PLANNING_RISK** (Flag) — Sprint plan has unrealistic capacity or scheduling assumptions. Raised by Risk Agent.
+
+**PR/Review Agent** (Agent 22) — Performs code review, secret scanning, and decision compliance checks on pull requests. Third decision enforcement checkpoint.
+
+**Product Manager** (Agent 34) — Phase 1 agent owning product roadmap and feature prioritization.
+
+**Project Brief** — Your requirements, pasted in the Command Center. Saved to `BusinessDocs/project-brief.md` and read by the Onboarding Agent.
+
+## Q–R
+
+**Quality Gate** — Two-stage validation (Critic + Risk) after each phase. Phase cannot proceed unless both pass. See [Quality Gates](quality-gates.md).
+
+**Questionnaire Agent** (Agent 36) — Generates customer-facing questions from `INSUFFICIENT_DATA:` items. See [Questionnaires](questionnaires.md).
+
+**Questionnaire Protocol** — Mandatory rule: agents check for injected questionnaire answers at start, compile remaining gaps at end, and never block handoff on missing answers.
+
+**Recommendations** (Deliverable Type) — Second output type from phase agents. Prioritized actions with effort, impact, SMART criteria, and source references.
+
+**Reevaluate Agent** (Agent 23) — Re-analyzes selected phases when new information is available. Performs delta scan and updates sprint backlog. See [Questionnaires — Reevaluation](questionnaires.md#the-reevaluation-workflow-in-detail).
+
+**REEVALUATE** (Command) — Triggers re-analysis with new information. Scopes: ALL, PHASE-1 through PHASE-4, DELTA-ONLY.
+
+**REFRESH ONBOARDING** (Command) — Rescans workspace and tooling without repeating intake questions. Updates onboarding-output.md while preserving answers.
+
+**Retrospective Agent** (Agent 28) — Analyzes sprint performance, calculates velocity, detects patterns, updates lessons-learned.md and velocity-log.json.
+
+**Risk Agent** (Agent 19) — Independent risk assessor checking strategic alignment, implementation feasibility, compliance, and cross-domain risks. Second part of quality gate. See [Quality Gates](quality-gates.md).
+
+## S
+
+**SCOPE CHANGE** (Command) — Handles fundamental project direction changes (business model pivot, architecture change, target audience change). Dimensions: BUSINESS, TECH, UX, MARKETING, ALL. See [Advanced Commands](advanced-commands.md#scope-change--change-project-direction).
+
+**SCOPE_CHANGE_HOLD** (Story Status) — Sprint stories affected by a scope change are held pending reconciliation. Reversible. Completed work is tagged `COMPLETED_UNREVIEWED` instead.
+
+**Scope Discipline** — Mandatory rule: each agent operates exclusively within its defined domain.
+
+**SCOPE_VIOLATION** (Flag) — Recommendation outside the agent's domain. Raised by Critic Agent.
+
+**Security Architect** (Agent 08) — Phase 2 agent performing threat modeling and security architecture.
+
+**Senior Developer** (Agent 06) — Phase 2 agent assessing implementation feasibility and code standards.
+
+**session-state.json** — Single source of truth for progress. Records agent completion, phase progress, sprint queue, decisions, and blockers. Enables CONTINUE command.
+
+**SKIPPED_NO_TOKEN** (Brand Status) — Brand & Assets Agent ran without Canva API token. Guidelines and design tokens are still produced from text; only Canva-dependent assets are skipped.
+
+**Software Architect** (Agent 05) — Phase 2 agent designing system architecture and selecting technology stack.
+
+**Sprint** — Time-boxed implementation cycle in Phase 5. See [Sprints](sprints.md).
+
+**Sprint Gate** — Decision checkpoint before every sprint. Checks open decisions, loads constraints, injects lessons learned, and lets you choose IMPLEMENT or BACKLOG. See [Sprints](sprints.md#the-sprint-gate).
+
+**Sprint ID** — Unique identifier. Format: `SP-[N]` for regular sprints, `FT-[FEATURENAME]-S[N]-[NNN]` for feature sprints, `HOTFIX-[N]` for hotfixes.
+
+**Sprint Plan** (Deliverable Type) — Third output type from phase agents. Contains capacity assumptions, stories with acceptance criteria, and Definition of Done.
+
+**Story** — Single unit of work within a sprint. Types: CODE, INFRA, CONFIG, DESIGN, CONTENT, ANALYSIS, DOCS.
+
+**Story Point** — Relative estimation unit for complexity. Definition of Ready requires CODE/INFRA ≤ 8 points.
+
+**Storybook Agent** (Agent 31) — Sets up and maintains the component library. Produces component-inventory.md and design tokens (CSS/JS). Enforces Rule ORC-18. See [Synthesis](synthesis.md#storybook-agent).
+
+**STRATEGIC_MISALIGNMENT** (Flag) — Phase output conflicts with business goals from Phase 1. Raised by Risk Agent.
+
+**Synthesis Agent** (Agent 17) — Combines all phase outputs into 6 final reports. See [Synthesis](synthesis.md).
+
+## T–U
+
+**Test Agent** (Agent 21) — Validates code quality and decision compliance. Returns code to Implementation Agent if violations found. Second decision enforcement checkpoint.
+
+**UNCERTAIN:** (Prefix) — Unverified claim. Used to distinguish uncertain assertions from verified findings. Cannot later be repeated as fact.
+
+**UNVERIFIED_CLAIM** (Flag) — Assertion not traceable to input artifacts. Raised by Critic Agent.
+
+**UI Designer** (Agent 12) — Phase 3 agent creating visual design and component patterns.
+
+**UX Designer** (Agent 11) — Phase 3 agent producing information architecture and interaction design.
+
+**UX Researcher** (Agent 10) — Phase 3 agent conducting user research and creating personas/journey maps.
+
+## V–W
+
+**Velocity** — Sprint performance metric: planned vs. actual story point completion rate. Below 80% for 2+ consecutive sprints triggers an Orchestrator warning.
+
+**Verification Protocol** — Mandatory 9-point Handoff Checklist every agent must complete before yielding control.
+
+---
+
+## See Also
+
+- [Commands Reference](commands.md) — all available commands
+- [Agents](agents.md) — full agent list with descriptions
+- [Pipeline](pipeline.md) — the phase execution sequence
+- [Getting Started](getting-started.md) — how to begin

--- a/.github/help/onboarding.md
+++ b/.github/help/onboarding.md
@@ -1,0 +1,149 @@
+# Onboarding
+
+## What is onboarding?
+
+Onboarding is the **mandatory first step** of every project cycle — whether you run `CREATE`, `AUDIT`, or `FEATURE`. The Onboarding Agent collects, validates, and structures all the input that the 38 downstream agents need. No other agent starts until onboarding is complete.
+
+---
+
+## What happens during onboarding?
+
+The process has 5 steps, executed in order:
+
+### Step 0 — Load prior answers
+If you've run a previous cycle, the agent checks `BusinessDocs/` for existing questionnaire answers. Found answers are automatically made available to all future phase agents, so you never need to repeat yourself.
+
+### Step 1 — Input inventory
+The agent catalogs everything available:
+
+**In CREATE mode**, it looks for:
+- **Project name** (required)
+- **Problem statement** (required)
+- **Business model** and target audience
+- **Technology preferences** — language, framework, hosting, database
+- **Constraints** — budget, timeline, team size, regulatory requirements
+- **Reference materials** — competitor analysis, brand guidelines, user research, existing code
+
+**In AUDIT mode**, it looks for:
+- **Codebase path or repository URL** (required)
+- **Audit objective** (required)
+- **Documentation** — README, architecture docs, API specs, test docs
+- **Previous audit results**
+
+**In both modes**, it checks tooling (Git, file system, test runner, linter, build tool) and GitHub configuration.
+
+> **Tip — use the Project Brief field.** In the Command Center, paste your full requirements into the **Project Brief** field before sending the command. This saves the brief as `BusinessDocs/project-brief.md`, which the Onboarding Agent reads directly from disk. This avoids context window overload and network timeouts.
+
+### Step 2 — Minimum input validation
+The agent checks whether required fields are present:
+
+| Input | Required (CREATE) | Required (AUDIT) |
+|-------|-------------------|-------------------|
+| Project name / description | YES | — |
+| Problem statement | YES | — |
+| At least one stakeholder input | YES | — |
+| Codebase accessible | — | YES |
+| Audit objective | — | YES |
+| At least one documentation source | — | YES |
+| **GitHub project name** | **YES (both)** | **YES (both)** |
+
+**If a required item is missing**, the cycle halts:
+```
+ONBOARDING_BLOCKED: [item] missing.
+Required action: [what you need to provide]
+Cycle does NOT start until this is resolved.
+```
+
+**If a recommended item is missing**, it's recorded as `INSUFFICIENT_DATA:` and downstream agents are told. They'll work with what's available and may generate questionnaire questions for you later.
+
+### Step 3 — Codebase / reference scan
+
+**AUDIT mode:** The agent performs a non-invasive surface scan — language detection, framework detection, directory structure (2 levels), CI/CD configuration, test structure, and a count of `TODO`/`FIXME`/`HACK` comments. It never reads secrets or credentials.
+
+**CREATE mode:** If you provided a reference codebase, the same scan runs. Otherwise this step is skipped — that's normal for greenfield projects.
+
+### Step 4 — Tooling verification
+The agent checks which tools are available (Git, file system access, test runner, linter, build tool) and documents their versions. Missing tools are flagged as `TOOLING_GAP` — this doesn't block Phases 1–4 (analysis and design), but it will block Phase 5 (implementation) if critical tools are missing.
+
+### Step 5 — Session state finalized
+The agent updates `session-state.json` to `ONBOARDING_COMPLETE` and records the output path, GitHub project name, and any `INSUFFICIENT_DATA` items. The Orchestrator takes over from here.
+
+---
+
+## Questions the system will ask you
+
+During onboarding, you'll be asked at least two questions directly:
+
+### 1. GitHub project name (mandatory)
+```
+What should be the name of the GitHub Kanban project
+on which all work items will be published?
+Example names: "Lumio Workitems", "[Project name] Board", "Sprint Backlog"
+```
+This name is used by the GitHub Integration Agent to create (or reuse) a project board.
+
+### 2. Canva API token (optional)
+```
+Do you have a Canva Connect API token available?
+The Brand & Assets Agent uses it to automatically create brand assets.
+Without a token this step is skipped and design tokens are filled manually.
+Enter the token, or type SKIP to continue without Canva integration.
+```
+
+---
+
+## What makes a good project brief?
+
+The quality of your onboarding input directly affects the quality of all 38 downstream agents. Here's what makes a brief effective:
+
+**Include:**
+- A clear problem statement — *what problem does this solve and for whom?*
+- Target audience description — *who uses this and what are their needs?*
+- Technology preferences — even "no preference" is useful information
+- Constraints — budget, timeline, team size, regulatory requirements
+- Reference materials — competitor URLs, existing brand guidelines, user research
+
+**Avoid:**
+- Vague goals like "build a good app" — be specific about what success looks like
+- Conflicting requirements without prioritization — state what matters most
+- Missing context — don't assume the agents know your industry domain
+
+**How much detail is enough?**
+More is better. A one-paragraph brief produces generic results. A 2–3 page brief with specific requirements, constraints, and examples produces targeted, actionable outputs across all phases.
+
+---
+
+## What happens after onboarding?
+
+The Orchestrator routes to Phase 1 (Business Analysis). From here, the cycle proceeds automatically through all phases:
+
+```
+Onboarding → Phase 1 (Business) → Critic/Risk → Phase 2 (Tech) → Critic/Risk
+  → Phase 3 (UX) → Critic/Risk → Phase 4 (Marketing) → Critic/Risk
+  → Brand & Assets → Storybook → Synthesis → GitHub Publication → Phase 5 (Sprints)
+```
+
+At each phase boundary, you'll be asked to start a fresh Copilot Chat conversation and type `CONTINUE`. All progress is preserved in `session-state.json`.
+
+---
+
+## INSUFFICIENT_DATA vs. ONBOARDING_BLOCKED
+
+| Label | Meaning | Your action |
+|-------|---------|-------------|
+| `ONBOARDING_BLOCKED` | A required item is missing. Cycle will not start. | Provide the missing input. |
+| `INSUFFICIENT_DATA` | A recommended item is missing. Cycle continues. | Optionally provide later via a questionnaire answer. |
+
+Items marked `INSUFFICIENT_DATA` during onboarding become candidates for **questionnaire questions** — the Questionnaire Agent may ask you about them after Phase 1 or later phases complete. Your answers are injected into agent context automatically.
+
+---
+
+## Re-running onboarding
+
+If your project setup changes (e.g., new tooling installed, repository moved), you can refresh the scan without re-answering intake questions:
+
+```
+REFRESH ONBOARDING
+```
+
+This runs Steps 3 and 4 only (codebase scan + tooling verification) and updates `onboarding-output.md`. Your original intake answers are preserved.

--- a/.github/help/pipeline.md
+++ b/.github/help/pipeline.md
@@ -38,7 +38,7 @@ After you queue a command but before you paste it in Copilot Chat, the pipeline 
 - A step-by-step checklist of what's happened and what's next
 - A tip that the page auto-refreshes every 10 seconds
 
-**Be patient** — after you paste the command in Copilot Chat, the Orchestrator needs to initialize the session and start the first agent. This can take up to a minute. The waiting state will transition to the full pipeline view automatically once the Orchestrator creates `session-state.json`.
+**Be patient** — after you paste the command in Copilot Chat, the Orchestrator immediately creates `session-state.json` (per ORC-46) and starts the Onboarding Agent. The waiting state will transition to the full pipeline view within seconds once the Orchestrator writes the initial session state.
 
 ## One agent at a time
 

--- a/.github/help/quality-gates.md
+++ b/.github/help/quality-gates.md
@@ -1,0 +1,206 @@
+# Quality Gates — Critic + Risk Validation
+
+Every phase in this system must pass **two independent quality gates** before the next phase can begin. This page explains what these gates check, how they work, and what happens when they fail.
+
+---
+
+## How It Works
+
+After every phase completes (all agents in that phase have handed off), the Orchestrator automatically triggers a two-step validation:
+
+```
+Phase agents complete
+  ↓
+Critic Agent — checks quality of deliverables
+  ↓
+Risk Agent — checks strategic and implementation risks
+  ↓
+Both PASSED? → next phase starts
+Either FAILED? → failing agent must revise and resubmit
+```
+
+This gate runs **4 times** during a full creation cycle (once per Phase 1–4) and **once per sprint** during Phase 5 implementation.
+
+> **Rule ORC-01:** The next phase NEVER starts before the current phase is fully completed AND validated by both the Critic Agent and the Risk Agent.
+
+---
+
+## What the Critic Agent Checks
+
+The Critic Agent is the **quality guardian**. It does not produce analyses or make recommendations — it only validates. It checks five things:
+
+### 1. Contract Compliance
+Every agent produces deliverables that must match an output contract. The Critic checks:
+
+| Contract | Key Checks |
+|----------|-----------|
+| **Analysis** | Minimum 5 findings with sources, gaps with priorities, risks scored, KPI baseline present, valid JSON export |
+| **Recommendations** | Every recommendation references an analysis finding, no empty impact fields, SMART measurement criteria, priority matrix |
+| **Sprint Plan** | Capacity assumptions documented, all stories have acceptance criteria, Definition of Done present, all P1/P2 recommendations covered by stories |
+| **Guardrails** | All guardrails formulated testably, violation action present for each |
+
+### 2. Anti-Hallucination Compliance
+- Numbers, percentages, or KPIs without a source → `HALLUCINATION_FLAG`
+- Claims not traceable to input artifacts → `UNVERIFIED_CLAIM`
+- `UNCERTAIN:` claims later repeated as fact → `INCONSISTENCY_FLAG`
+- Recommendations outside the agent's domain → `SCOPE_VIOLATION`
+
+### 3. Internal Consistency
+- Contradictions within one agent's output
+- Contradictions between agents in the same phase
+
+### 4. Completeness
+- All mandatory sections present and non-empty (no placeholders)
+- All `INSUFFICIENT_DATA:` items have matching `QUESTIONNAIRE_REQUEST`
+- Code coverage ≥ 60% for Senior Developer entry points and business logic
+
+### 5. Decision Register Compliance
+The Critic loads `.github/docs/decisions.md` and verifies no recommendation contradicts a `DECIDED` item. Conflicts are flagged as `CRITIC_DECISION_CONFLICT`.
+
+### Critic Verdicts
+
+Each agent receives one of two verdicts:
+
+| Verdict | Meaning |
+|---------|---------|
+| **APPROVED** | All checks passed — agent output is valid |
+| **NEEDS_REVISION** | One or more checks failed — specific remediation instructions are sent back |
+
+The phase verdict is:
+- **Phase APPROVED** — all agents in the phase received APPROVED
+- **Phase NEEDS_REVISION** — one or more agents received NEEDS_REVISION
+
+---
+
+## What the Risk Agent Checks
+
+The Risk Agent performs an **independent risk assessment** on the same phase output. It runs in parallel with (or immediately after) the Critic. Its focus is broader:
+
+### 1. Strategic Alignment
+Are the phase outputs consistent with the business goals from Phase 1? For example:
+- Do technical recommendations (Phase 2) respect business constraints?
+- Do UX recommendations (Phase 3) respect technical constraints?
+- Misalignment → `STRATEGIC_MISALIGNMENT`
+
+### 2. Implementation Feasibility
+- Are capacity assumptions in sprint plans realistic?
+- Are dependencies correctly mapped?
+- Are items technically feasible within the suggested sprint?
+- Unrealistic items → `PLANNING_RISK`
+
+### 3. Compliance Risks
+- Do any recommendations introduce legal or regulatory risks?
+- Are there regulatory deadlines that affect the roadmap?
+
+### 4. Recommendation Risks
+- Risks of executing a recommendation
+- Risks of NOT executing a recommendation
+- Second-order effects
+
+### 5. System (Cross-Domain) Risks
+- Conflicting recommendations between disciplines
+- Dependencies that could block the entire roadmap
+- Single points of failure
+
+### 6. Decision Register Compliance
+Like the Critic, the Risk Agent loads `.github/docs/decisions.md`. Any recommendation that contradicts a `DECIDED` item automatically receives risk score `HIGH`.
+
+### Risk Verdicts
+
+Each agent receives a risk profile scored as:
+
+| Risk Level | Meaning |
+|------------|---------|
+| **LOW** | No significant risks identified |
+| **MEDIUM** | Manageable risks that should be monitored |
+| **HIGH** | Serious risks requiring mitigation before proceeding |
+| **CRITICAL** | Showstopper — phase cannot proceed without resolution |
+
+The phase risk verdict is:
+- **Phase APPROVED** — no HIGH or CRITICAL risks unresolved
+- **Phase NEEDS_REVIEW** — one or more HIGH risks remain
+- **Phase BLOCKED** — one or more CRITICAL risks remain
+
+---
+
+## What Happens When Validation Fails
+
+### Normal Remediation Flow
+
+1. The Orchestrator receives the failing verdicts
+2. Specific remediation instructions are sent to the failing agent(s)
+3. The agent revises its output and resubmits
+4. Critic + Risk validation runs again on the revised output
+
+### Maximum 3 Cycles
+
+If the same phase fails Critic/Risk validation **three times**, the Orchestrator escalates to you with three options:
+
+| Option | What It Does |
+|--------|-------------|
+| **ACCEPT_WITH_RISK** | Proceed despite the gaps — documented as known risks |
+| **MANUAL_OVERRIDE** | You edit the deliverable yourself |
+| **RETRY_SIMPLIFIED** | Re-run the failing agent with reduced scope |
+
+Your choice is documented in the Orchestrator Log.
+
+### Critic Meta-Validation
+
+If the Critic returns PASSED with **zero findings** despite the phase having open `UNCERTAIN:` or `INSUFFICIENT_DATA:` items, the Orchestrator flags this as `CRITIC_REVIEW_SUSPICIOUS` and requires the Critic to justify why each open item was not referenced.
+
+---
+
+## Quality Gates in Phase 5 (Sprints)
+
+During implementation, a lighter version of Critic + Risk runs **per sprint**. The focus shifts to:
+- Story acceptance criteria met
+- Test coverage requirements satisfied
+- No regression in existing tests
+- Secret scan passed on PRs
+- Implementation traceable to approved recommendations
+
+---
+
+## Quality Gates During Special Commands
+
+| Command | Quality Gate Behavior |
+|---------|----------------------|
+| **FEATURE** | Full Critic + Risk cycle on the feature's mini-phases |
+| **SCOPE CHANGE** | Critic + Risk on the re-analysis output (with scope change context) |
+| **HOTFIX** | Sprint Gate BYPASS — abbreviated validation (secret scan still mandatory) |
+| **REEVALUATE** | Critic + Risk on the re-evaluation output |
+
+During a **Scope Change**, the Critic checks an additional requirement: every re-analysis agent must include a `## Scope Change Impact` section as the first section, stating which previous findings are confirmed, superseded, or net-new.
+
+---
+
+## Flags You May See
+
+| Flag | Source | Meaning |
+|------|--------|---------|
+| `HALLUCINATION_FLAG` | Critic | Data cited without a verifiable source |
+| `UNVERIFIED_CLAIM` | Critic | Claim not traceable to any input |
+| `INCONSISTENCY_FLAG` | Critic | `UNCERTAIN:` item later stated as fact |
+| `SCOPE_VIOLATION` | Critic | Recommendation outside the agent's domain |
+| `INCOMPLETE` | Critic | Mandatory section missing or placeholder |
+| `CRITIC_DECISION_CONFLICT` | Critic | Recommendation contradicts a DECIDED item |
+| `CRITIC_REVIEW_SUSPICIOUS` | Orchestrator | Critic PASSED suspiciously — no findings despite open issues |
+| `STRATEGIC_MISALIGNMENT` | Risk | Output conflicts with business strategy |
+| `PLANNING_RISK` | Risk | Sprint plan has unrealistic assumptions |
+| `DECISION_CONFLICT_RISK` | Risk | Recommendation contradicts a DECIDED item (scored HIGH) |
+
+---
+
+## Where to Find the Results
+
+After Critic + Risk validation, the results are stored in the phase output directory and referenced in `session-state.json`. The Orchestrator Log (in the conversation) will also show whether the phase was approved, needs revision, or is blocked.
+
+---
+
+## See Also
+
+- [Getting Started](getting-started.md) — overview of the full pipeline
+- [Pipeline](pipeline.md) — what happens in each phase
+- [Sprints](sprints.md) — how Sprint Gates work in Phase 5
+- [Decisions](decisions.md) — how decisions influence quality gate checks
+- [Troubleshooting](troubleshooting.md) — what to do when something fails

--- a/.github/help/questionnaires.md
+++ b/.github/help/questionnaires.md
@@ -41,3 +41,85 @@ After answering questionnaires, you can trigger a **Reevaluate** to have the age
 4. Copy the generated command into Copilot chat
 
 Items resolved by your answers will be marked `RESOLVED_BY_QUESTIONNAIRE`.
+
+---
+
+## The Reevaluation Workflow in Detail
+
+### What happens when you trigger REEVALUATE
+
+The `REEVALUATE [scope]` command starts a multi-step process:
+
+```
+REEVALUATE [scope]
+  → Questionnaire Agent loads all answered questions
+  → Reevaluate Agent performs a Delta Scan (what changed?)
+  → Phase agents re-analyze (only affected phases)
+  → Critic + Risk validation on updated output
+  → Questionnaire Agent generates new questions (if new gaps found)
+  → Sprint backlog is updated with the impact
+```
+
+### Scope options
+
+| Scope | What gets re-analyzed |
+|-------|----------------------|
+| `PHASE-1` | Business & Strategy (agents 01–04, 34) |
+| `PHASE-2` | Technology & Architecture (agents 05–09, 33) |
+| `PHASE-3` | UX & Product Experience (agents 10–13, 32, 35) |
+| `PHASE-4` | Brand, Marketing & Growth (agents 14–16) |
+| `ALL` | All four phases completely |
+| `DELTA-ONLY` | Only detect what changed — no full re-analysis |
+
+### How your answers are used
+
+1. **Before the delta scan starts**, the Questionnaire Agent loads all answers you have provided (both via the web UI and via direct file edits — both work identically)
+2. Each answered question that resolves a previously open `INSUFFICIENT_DATA:` item is flagged as `RESOLVED_BY_QUESTIONNAIRE: [Q-ID]`
+3. These resolved items are treated as **new findings** in the delta scan (type: `RESOLVED`)
+4. Phase agents receive your answers as injected context when they re-run their analysis
+
+### What the delta scan produces
+
+The Reevaluate Agent compares the current state against the previous analysis and classifies every finding:
+
+| Classification | Meaning |
+|---------------|---------|
+| **NEW** | Something not present before |
+| **RESOLVED** | Previously open item that is now fixed or answered |
+| **CHANGED** | Severity, context, or impact has shifted |
+| **UNCHANGED** | No change — carried over without repetition |
+
+### Impact on the sprint backlog
+
+The reevaluation also checks how changes affect existing sprint stories:
+
+| Sprint Status | What Can Change | What Cannot Change |
+|---------------|----------------|-------------------|
+| `QUEUED` | Stories can be adjusted, added, removed, reprioritized | Cannot start implementation |
+| `BACKLOG` | Stories can be adjusted, promoted, or deprioritized | Cannot start implementation |
+| `IN_PROGRESS` | Impact is flagged for your decision (continue / pause / rework) | Stories are NEVER removed or cancelled |
+| `COMPLETED` | Drift is documented if detected | Completed work is NEVER rolled back |
+
+### When new gaps appear
+
+If the re-analysis finds new `INSUFFICIENT_DATA:` items, the Questionnaire Agent generates **new questionnaires** after Critic + Risk validation. These appear in the Questionnaires tab for you to answer, and you can trigger another `REEVALUATE` cycle when ready.
+
+### Triggering via the web UI vs. chat
+
+You can trigger reevaluation two ways:
+
+| Method | How |
+|--------|-----|
+| **Web UI** | Click the Reevaluate button → the webapp writes `reevaluate-trigger.json` → the Orchestrator picks it up automatically at the next Sprint Gate |
+| **Chat** | Type `REEVALUATE [scope]` directly into Copilot chat |
+
+Both methods produce the same result. The web UI trigger is picked up at the next Sprint Gate (Step 0), while the chat command runs immediately.
+
+---
+
+## See Also
+
+- [Quality Gates](quality-gates.md) — how Critic + Risk validation works during reevaluation
+- [Sprints](sprints.md) — how Sprint Gate handles reevaluation triggers
+- [Decisions](decisions.md) — how decisions interact with reevaluation
+- [Advanced Commands](advanced-commands.md) — REEVALUATE vs SCOPE CHANGE (when to use which)

--- a/.github/help/sprints.md
+++ b/.github/help/sprints.md
@@ -1,0 +1,218 @@
+# Sprints & Implementation (Phase 5)
+
+## What is Phase 5?
+
+Phase 5 is where the designs from Phases 1–4 become working software. The system breaks the work into **sprints** — time-boxed implementation cycles where stories (units of work) flow through a pipeline of agents.
+
+Phase 5 only begins after:
+1. All four design phases are complete.
+2. The Synthesis Agent has produced 6 documents (master report, 4 department reports, cross-team blocker matrix).
+3. You have **APPROVED** all synthesis outputs.
+4. The GitHub Integration Agent has published all stories as GitHub Issues.
+
+---
+
+## Sprint lifecycle
+
+Each sprint follows this cycle:
+
+```
+Sprint Gate (you choose IMPLEMENT or BACKLOG)
+  ↓
+Definition of Ready check (are stories ready?)
+  ↓
+Implementation Agent (writes code per story)
+  ↓
+Test Agent (validates code + decision compliance)
+  ↓
+PR/Review Agent (reviews diff, secret scan, merge)
+  ↓
+KPI Agent (measures sprint metrics)
+  ↓
+Documentation Agent (updates manuals + changelog)
+  ↓
+GitHub Integration Agent (closes issues, updates board)
+  ↓
+Retrospective Agent (velocity analysis, lessons learned)
+  ↓
+Next Sprint Gate
+```
+
+This is a **closed loop** — the Orchestrator controls each handoff. You don't need to trigger agents manually.
+
+---
+
+## The Sprint Gate
+
+The Sprint Gate is the most important decision point in the system. It runs **before every sprint** and determines whether the sprint proceeds.
+
+### What happens at the gate
+
+1. **Decision check** — The Orchestrator reads all open decisions from `.github/docs/decisions.md` and the decision category files.
+   - `OPEN` + `HIGH` priority + scope matches this sprint → **gate blocks** until you answer.
+   - `OPEN` + `MEDIUM`/`LOW` → reported as informational, no block.
+   - All `DECIDED` items are loaded as constraints for the sprint.
+
+2. **Sprint presentation** — You see:
+   ```
+   SPRINT GATE – SP-1: "Core Authentication"
+   Goal: Implement user login, registration, and session management
+   Stories: 5 | Story points: 21 | Depends on: NONE
+
+   Choose an action:
+     [1] IMPLEMENT – activate this sprint now
+     [2] BACKLOG – defer this sprint
+   ```
+
+3. **Your choice:**
+   - **IMPLEMENT** → Sprint starts. Stories are assigned to agents.
+   - **BACKLOG** → Sprint is deferred. All dependent sprints are also deferred (cascade). The system moves to the next queued sprint.
+
+### When the gate blocks
+
+If you have an unanswered `HIGH` priority decision whose scope matches the sprint, you'll see:
+
+```
+⚠️ SPRINT GATE BLOCKED – Outstanding decision required
+Decision ID: DEC-007
+Question: Which database engine for user storage?
+Scope: SP-1
+→ Answer via .github/docs/decisions.md or the web UI Decisions tab.
+→ Type RESUME to restart the Sprint Gate.
+```
+
+The sprint cannot proceed until you answer or defer the decision.
+
+### Lessons learned injection
+
+If previous sprints have completed, the Orchestrator also loads the top-3 lessons from `lessons-learned.md` and adjusts story point estimates based on actual velocity data.
+
+---
+
+## Story types
+
+Not all stories go through the full code pipeline. The system recognizes these types:
+
+| Type | Pipeline | Your role |
+|------|----------|-----------|
+| **CODE** | Implementation → Test → PR/Review | Automated. You review PRs. |
+| **INFRA** | Implementation → Test → PR/Review | Automated. Infrastructure changes. |
+| **CONFIG** | Implementation → Test → PR/Review | Automated. Configuration-only changes. |
+| **DESIGN** | Manual | You create the design artifact. Mark as COMPLETED or BLOCKED at the next Sprint Gate. |
+| **CONTENT** | Manual | You write the content. Mark as COMPLETED or BLOCKED at the next Sprint Gate. |
+| **ANALYSIS** | Manual | You produce the analysis document. Mark at Sprint Gate. |
+| **DOCS** | Documentation Agent | Automated. Agent updates manuals. |
+
+Manual story types (DESIGN, CONTENT, ANALYSIS) **never block** code stories in the same sprint. If a code story depends on a manual deliverable that isn't ready, the code story is deferred to the next sprint.
+
+---
+
+## Definition of Ready
+
+Before a story enters implementation, it must pass a readiness check:
+
+**For CODE and INFRA stories:**
+- At least 2 concrete acceptance criteria
+- All dependencies resolved or explicitly accepted
+- Completable in one sprint (≤ 8 story points)
+
+**For DOCS, CONFIG, and other non-CODE stories:**
+- At least 1 acceptance criterion
+- A deliverable path (file or artifact location)
+- An assigned owner
+
+A story that fails the Definition of Ready is moved to the next sprint automatically. After 2 consecutive failures, you're asked to **SPLIT**, **OVERRIDE**, **REMOVE**, or **DEFER** the story.
+
+---
+
+## Decision enforcement during sprints
+
+Every `DECIDED` item from your decisions is enforced at three checkpoints:
+
+| Checkpoint | Agent | What happens on violation |
+|-----------|-------|--------------------------|
+| Before coding | Implementation Agent | Halts and reports the conflict |
+| During testing | Test Agent | Returns code to Implementation Agent |
+| At PR review | PR/Review Agent | Blocks merge until resolved |
+
+If a story requires a technology whose decisions are `DEFERRED` (e.g. Docker, .NET), the system automatically activates that decision category without needing your input.
+
+For full details, see the [Decisions help file](decisions.md).
+
+---
+
+## The GitHub board
+
+The GitHub Integration Agent manages a Kanban board with 5 columns:
+
+| Column | Stories land here when… |
+|--------|------------------------|
+| **Backlog** | Sprint is queued or deferred |
+| **Ready** | Sprint is queued and story has no blockers |
+| **In Progress** | Sprint is active, story is being implemented |
+| **In Review** | A PR is open for the story |
+| **Done** | PR is merged and tests pass |
+
+After every sprint, the agent closes implemented issues and labels blocked ones. You can track progress at any time from your GitHub project board.
+
+### Issue structure
+
+Each published Issue includes:
+- Sprint ID and story ID in the title
+- Story type, priority, and acceptance criteria in the body
+- Labels for type (`type: code`, `type: infra`, etc.) and priority (`priority: high`, etc.)
+- Sprint milestone assignment
+
+---
+
+## Sprint completion
+
+After the PR/Review Agent merges code, several things happen automatically:
+
+1. **KPI Agent** measures sprint metrics (velocity, defect rate, code coverage, etc.) and writes a report to `.github/docs/metrics/sprint-[SP-N]-kpi.json`.
+2. **Documentation Agent** updates `docs/user-manual.md`, `docs/technical-manual.md`, and `CHANGELOG.md` based on what was implemented.
+3. **GitHub Integration Agent** closes completed issues and updates the board.
+4. **Retrospective Agent** analyzes the sprint, calculates velocity, detects patterns, and writes lessons learned.
+
+Only after the retrospective is complete does the next Sprint Gate open.
+
+---
+
+## Velocity and learning
+
+The Retrospective Agent maintains two cumulative files:
+
+- **`velocity-log.json`** — Machine-readable velocity data per sprint (planned vs. actual story points, completion rate).
+- **`lessons-learned.md`** — Human-readable lessons, ranked by urgency, injected into the next sprint's context.
+
+If velocity drops below 80% for 2+ consecutive sprints, the Orchestrator warns you at the Sprint Gate and suggests adjusting capacity.
+
+---
+
+## Backlogged sprints
+
+When you choose **BACKLOG** at a Sprint Gate:
+- The sprint and all its dependents are deferred.
+- Backlogged sprints are re-presented after every active sprint completes.
+- If all remaining sprints are backlogged, the Orchestrator asks: *"All remaining sprints are in the backlog. Do you want to implement a sprint after all, or is the current implementation cycle complete?"*
+
+---
+
+## When Phase 5 ends
+
+Phase 5 is complete when:
+- All sprints are either IMPLEMENTED or permanently BACKLOGGED.
+- Every implemented sprint has: secret scan PASSED, KPI report written, PRs merged, manuals updated, GitHub board updated, retrospective complete.
+- No unresolved `BLOCKING` items remain in the sprint plan.
+
+---
+
+## Quick reference
+
+| What you do | When |
+|------------|------|
+| Answer OPEN HIGH decisions | Before sprint start (Sprint Gate blocks) |
+| Choose IMPLEMENT or BACKLOG | At every Sprint Gate |
+| Review PRs | When the PR/Review Agent creates them |
+| Complete DESIGN/CONTENT/ANALYSIS stories | During the sprint, mark at next Sprint Gate |
+| Read retrospective and KPI reports | After each sprint completes |

--- a/.github/help/synthesis.md
+++ b/.github/help/synthesis.md
@@ -1,0 +1,203 @@
+# Synthesis — Final Reports, Brand & Storybook
+
+After all four design phases complete and pass Critic + Risk validation, the system produces a set of final deliverables. This page explains what those deliverables are, how to read them, and what the Brand & Storybook agents contribute.
+
+---
+
+## Overview
+
+The synthesis stage produces **6 documents** in `.github/docs/synthesis/`:
+
+| Document | File | Audience |
+|----------|------|----------|
+| **Master Report** | `final-report-master.md` | Board, management, governance |
+| **Business Report** | `final-report-business.md` | Business Analyst, Sales, Finance, Domain owners |
+| **Technology Report** | `final-report-tech.md` | Engineering, DevOps, Security, Data teams |
+| **UX Report** | `final-report-ux.md` | UX/UI designers, Product owners, Accessibility |
+| **Marketing Report** | `final-report-marketing.md` | Marketing, Growth, CRO teams |
+| **Cross-Team Blocker Matrix** | `cross-team-blocker-matrix.md` | All teams + Orchestrator |
+
+Before these reports are generated, two additional agents run (if marketing was in scope): the **Brand & Assets Agent** and the **Storybook Agent**.
+
+---
+
+## The Master Report
+
+The master report is the executive-level document. It contains:
+
+### 1. Executive Summary (max 2 pages)
+- What is the product and for whom
+- Solution overview (CREATE mode) or current state (AUDIT mode)
+- Top-5 strategic priorities across all domains
+- Overall risk profile
+- Investment ratio (effort vs expected return)
+
+### 2. Solution Blueprint Heatmap (CREATE) / Capability Heatmap (AUDIT)
+A matrix showing readiness across all dimensions:
+- **Rows:** business capabilities or product features
+- **Columns:** Business | Technical | UX | Marketing readiness
+- **Color coding:** Ready for Implementation / Needs Refinement / Blocked / Not Yet Designed
+
+### 3. Risk Matrix
+All risks from all phases consolidated and sorted by risk score (highest first). Each risk includes probability, impact, mitigation, and owner. Linked risks that reinforce each other are identified.
+
+### 4. 12-Month Roadmap
+A quarterly breakdown of deliverables, dependencies, KPI targets, and blocked items. In CREATE mode, milestones are framed as build targets ("MVP launch", "Feature X shipped"). In AUDIT mode, they're framed as remediation steps.
+
+### 5. Combined Guardrails
+All guardrails from all phases merged, deduplicated, and conflict-resolved.
+
+### 6. KPI Dashboard
+All KPIs from all phases with current baselines, 6-month targets, 12-month targets, and measurement-responsible discipline.
+
+### 7. Open Items
+All unresolved `UNCERTAIN:` and `INSUFFICIENT_DATA:` items with routing information.
+
+### 8. Scope Change History (if applicable)
+If any `SCOPE CHANGE` commands were executed, each event is documented with dimension, date, invalidated sections, and resulting premise changes.
+
+---
+
+## Department Reports
+
+Each department report follows the **same 8-section structure** and is fully self-contained — the relevant team can act without reading the master report:
+
+| Section | Content |
+|---------|---------|
+| **1. Summary** | Design decisions and specifications from this team's perspective |
+| **2. Recommendations** | Prioritized list with source agent, effort, and impact |
+| **3. Roadmap** | 12-month items for this team, with dependencies and KPI targets |
+| **4. KPIs** | Baselines and targets for this team's metrics |
+| **5. Blockers from other teams** | Items this team cannot start without input from another team (always present, even if "no blockers") |
+| **6. Advisory alignments** | Nice-to-have coordination with other teams |
+| **7. Open items** | Filtered `UNCERTAIN:` and `INSUFFICIENT_DATA:` items for this discipline |
+| **8. Guardrails** | Filtered subset of combined guardrails for this team |
+
+### Which Agents Feed Each Report
+
+| Report | Phase | Agents |
+|--------|-------|--------|
+| Business | Phase 1 | Business Analyst, Domain Expert, Sales Strategist, Financial Analyst, Product Manager |
+| Technology | Phase 2 | Software Architect, Senior Developer, DevOps Engineer, Security Architect, Data Architect, Legal Counsel |
+| UX | Phase 3 | UX Researcher, UX Designer, UI Designer, Accessibility Specialist, Content Strategist, Localization Specialist |
+| Marketing | Phase 4 | Brand Strategist, Growth Marketer, CRO Specialist |
+
+---
+
+## Cross-Team Blocker Matrix
+
+This is the **dependency map** between teams. It identifies:
+
+- **BLOCKING** dependencies — a team **cannot start** without this from another team
+- **ADVISORY** dependencies — coordination is helpful but not required
+
+Format: a matrix with teams on both axes, plus a detailed table listing each blocker with ID, priority, and recommended action.
+
+Every `BLOCKING` item must appear as `BLOCKED` in the corresponding sprint plan story. Missing linkage causes the Synthesis Agent to flag it.
+
+---
+
+## Brand & Assets Agent
+
+The Brand & Assets Agent runs **after Phase 4 passes Critic + Risk validation** and **before the Storybook Agent**. It converts Phase 4 brand strategy into usable digital assets.
+
+### What It Produces
+
+| Output | Location |
+|--------|----------|
+| Brand guidelines | `.github/docs/brand/brand-guidelines.md` |
+| Design tokens | `.github/docs/brand/design-tokens.json` |
+| Brand assets report | `.github/docs/brand/brand-assets-report.md` |
+| Visual assets (logos, social cards, banners) | `.github/docs/brand/assets/` |
+
+### Canva Integration
+
+If a Canva API token was provided during onboarding, the agent creates or updates a Canva Brand Kit and generates assets (social cards, banners, favicon, email headers, UI preview covers) via the Canva Connect API.
+
+If **no Canva token** was provided:
+- Status is set to `SKIPPED_NO_TOKEN`
+- The brand guidelines and design tokens are still produced (from Phase 4 text output)
+- Only the Canva-dependent visual assets are skipped
+- The Storybook Agent and Synthesis Agent continue with reduced brand data
+
+### What the Brand Guidelines Cover
+
+The brand guidelines document has 6 mandatory sections:
+1. Colors (primary, secondary, accent, neutral, semantic)
+2. Typography (primary and secondary typefaces, weights, usage)
+3. Logo variants (primary, white, black, icon)
+4. Tone of voice (keywords, examples)
+5. Forbidden combinations (what to never do)
+6. INSUFFICIENT_DATA log (gaps that need resolution)
+
+---
+
+## Storybook Agent
+
+The Storybook Agent runs **after the Brand & Assets Agent**. It sets up the component library that governs all UI implementation.
+
+### What It Produces
+
+| Output | Location |
+|--------|----------|
+| Component inventory | `.github/docs/storybook/component-inventory.md` |
+| Design tokens (CSS) | `src/tokens/tokens.css` |
+| Design tokens (JS) | `src/tokens/tokens.js` |
+| Storybook configuration | `.storybook/` directory |
+| Component stories | Per-component `.stories.js` files |
+
+### Why It Matters
+
+The Storybook component inventory is the **only approved UI building block set** for Phase 5 implementation:
+
+> **Rule ORC-18:** The Implementation Agent MUST NOT create or use UI components that are not documented in the Storybook component inventory. New components first require a Storybook story + review.
+
+This means:
+- Every UI component used in implementation must exist in Storybook first
+- New components require a Storybook story before they can be implemented
+- The PR/Review Agent enforces this on every pull request
+
+### Token Source Hierarchy
+
+The Storybook Agent uses this decision tree for design tokens:
+
+1. **Primary:** `.github/docs/brand/design-tokens.json` (from Brand & Assets Agent)
+2. **Fallback:** If design-tokens.json is missing or `SKIPPED_NO_TOKEN`, the Storybook Agent extracts tokens directly from Phase 4 Brand Strategist output
+
+Storybook always runs, regardless of whether Canva is available.
+
+---
+
+## Partial Runs
+
+If you ran only some disciplines (e.g., `CREATE TECH UX [project]`), synthesis behavior changes:
+
+- Only department reports for the executed phases are produced
+- Master Report and Cross-Team Blocker Matrix are **not** produced until all 4 phases are available
+- Department reports include a `PARTIAL_RUN` disclaimer noting which phases are missing
+- Run `CREATE SYNTHESIS` after completing remaining phases to get the full picture
+
+---
+
+## Reading the Reports
+
+### For Executives
+Start with the **Master Report**: Executive Summary → Heatmap → Risk Matrix → Roadmap.
+
+### For Team Leads
+Read **your department report** sections 1–5. Section 5 (Blockers) tells you what you need from other teams before you can start.
+
+### For the Orchestrator / System
+The **Cross-Team Blocker Matrix** drives sprint planning. Every `BLOCKING` item must be resolved or marked `BLOCKED` in the sprint plan before implementation begins.
+
+### For Developers
+The **Technology Report** (sections 2 and 8) plus the **Storybook component inventory** are your primary references during implementation.
+
+---
+
+## See Also
+
+- [Pipeline](pipeline.md) — the full phase sequence leading to synthesis
+- [Quality Gates](quality-gates.md) — Critic + Risk validation that must pass before synthesis
+- [Sprints](sprints.md) — how synthesis outputs feed into sprint planning
+- [File System Reference](../../docs/file-system-reference.md) — where all synthesis files live on disk

--- a/.github/help/troubleshooting.md
+++ b/.github/help/troubleshooting.md
@@ -1,0 +1,180 @@
+# Troubleshooting & Session Recovery
+
+## Session states — what they mean
+
+The system tracks its progress in `.github/docs/session/session-state.json`. Understanding the status helps you diagnose where things stand:
+
+| Status | Meaning | What to do |
+|--------|---------|-----------|
+| `ONBOARDING` | Onboarding has started but not completed | Provide any missing required input, then type CONTINUE |
+| `ONBOARDING_COMPLETE` | Ready for Phase 1 | Type CONTINUE to start Phase 1 |
+| `PHASE-1` through `PHASE-4` | Inside a design phase | Type CONTINUE to advance through agents |
+| `POST_PHASE_4` | Brand & Assets / Storybook agents running | Type CONTINUE |
+| `SYNTHESIS` | Synthesis Agent is producing reports | Review and APPROVE when presented |
+| `SPRINT_GATE` | Waiting for your IMPLEMENT/BACKLOG choice | Choose [1] or [2] as prompted |
+| `PHASE-5` | Inside a sprint cycle | Type CONTINUE to advance through agent pipeline |
+| `AWAITING_HUMAN` | An agent needs your input | Answer the open escalation (see below) |
+| `BLOCKED` | Unresolvable blocker detected | Read the blocker details and resolve the underlying issue |
+| `REEVALUATE` | A reevaluation cycle is running | Wait for it to complete, then type CONTINUE |
+| `SCOPE_CHANGE` | A scope change is being processed | Wait for reconciliation, then APPROVE |
+| `HOTFIX` | Emergency hotfix in progress | Follow the hotfix flow |
+| `COMPLETE` | All work is finished | No action needed |
+
+---
+
+## Resuming after interruption
+
+When you open a new Copilot Chat conversation, the Orchestrator automatically checks for an existing session. If one is found, you see:
+
+```
+SESSION RESUMED
+Session ID: [id]
+Started: [date]
+Last activity: [date]
+Status: [current status]
+Last agent: [agent name]
+Open escalations: [count]
+
+Choose:
+  [1] RESUME — continue from where stopped
+  [2] RESET — start new session (existing state is archived)
+```
+
+**RESUME** picks up exactly where you left off — all phase outputs, escalations, and decision constraints are reloaded.
+
+**RESET** archives the current session file (renamed to `session-state-[id]-archived.json`) and starts fresh via the Onboarding Agent.
+
+> **Tip:** At phase boundaries, the Orchestrator will tell you to start a fresh Copilot Chat conversation. This is by design — it prevents "JS heap out of memory" errors. Just open a new chat and type `CONTINUE`.
+
+---
+
+## Understanding human escalations
+
+When an agent needs your input, it produces a standardized block:
+
+```
+HUMAN INPUT REQUIRED
+
+Escalation ID: ESC-001
+Type: SCOPE_DECISION
+Raised by: Implementation Agent
+
+Situation: [what's happening]
+Question: [what you need to decide]
+  [1] Option A — [consequence]
+  [2] Option B — [consequence]
+
+Impact of no answer (timeout action: HALT):
+[what happens if you don't respond]
+```
+
+### Escalation types and how to respond
+
+| Type | How serious | What to do |
+|------|-------------|-----------|
+| `ONBOARDING_BLOCKED` | **Cycle stopped** | Provide the missing input (project name, codebase path, etc.) |
+| `TOOL_INSTALL_REQUEST` | **Cycle stopped** | Install the requested tool, then confirm |
+| `SPRINT_GATE` | **Sprint waiting** | Choose IMPLEMENT or BACKLOG |
+| `SPRINT_IMPACT_FLAG` | **Sprint paused** | Review the impact and decide how to proceed |
+| `SCOPE_DECISION` | **Cycle stopped** | Answer the question — often about unclear requirements |
+| `SCOPE_CHANGE_DECISION` | **Cycle stopped** | Choose between SCOPE CHANGE or OVERRIDE |
+| `AGENT_CONFLICT` | **Step paused** | Break the tie — the agents can't agree |
+| `SECURITY_DECISION` | **Cycle stopped** | A security issue needs your judgment |
+| `DESTRUCTIVE_GIT_OP` | **Cycle stopped** | Confirm or reject a destructive operation (force push, etc.) |
+| `OTHER` | **Step paused** | Read the question and respond |
+
+### Timeout behavior
+
+- **HALT** types: The entire cycle stops until you answer. Nothing proceeds.
+- **PAUSE** types: The specific step waits, but independent parallel work may continue.
+
+### How to answer
+
+Simply type the number of your choice (e.g., `1`) or provide free text if there are no numbered options. The Orchestrator links your answer to the escalation and resumes the cycle.
+
+---
+
+## Common problems
+
+### "CONTINUE" doesn't seem to work
+1. Make sure `session-state.json` exists at `.github/docs/session/session-state.json`.
+2. Check the `status` field — if it's `AWAITING_HUMAN` or `BLOCKED`, the system is waiting for specific input, not a generic CONTINUE.
+3. If the status is `COMPLETE`, there's nothing more to do. Start a new cycle with a CREATE or AUDIT command.
+
+### Session seems stuck at AWAITING_HUMAN
+An agent asked you a question and is waiting for your answer. Look for the `open_human_escalations` array in `session-state.json` — each entry shows the question, type, and what's expected. Answer the open escalation to resume.
+
+### Agent keeps returning work (loop)
+If the same story bounces between Implementation → Test → Implementation more than twice, the Orchestrator will escalate via `AGENT_CONFLICT`. This usually means:
+- Acceptance criteria are contradictory — clarify them.
+- A decision constraint conflicts with the story requirements — update the decision or the story.
+- A tooling issue prevents the test from passing — check the test output.
+
+### Sprint Gate keeps blocking
+Check `.github/docs/decisions.md` for any `OPEN` + `HIGH` priority decisions whose scope matches the sprint. Answer or defer them. Use the web UI Decisions tab for a visual overview.
+
+### "JS heap out of memory" in Copilot Chat
+This happens when a conversation accumulates too much context (many agents worth of output). **This is expected behavior.** Start a new Copilot Chat conversation and type `CONTINUE`. All progress is preserved in `session-state.json`.
+
+### Phase output seems missing
+Phase outputs are written to disk, not stored in chat. Check:
+- `BusinessDocs/Phase1-Business/` for Phase 1 outputs
+- `BusinessDocs/Phase2-Tech/` for Phase 2 outputs
+- `BusinessDocs/Phase3-UX/` for Phase 3 outputs
+- `BusinessDocs/Phase4-Marketing/` for Phase 4 outputs
+- `.github/docs/synthesis/` for synthesis reports
+
+If a file is referenced but doesn't exist, the Orchestrator may need to re-run the agent. Type `CONTINUE` and the Orchestrator will detect the gap.
+
+### Server won't start (webapp)
+- Ensure Node.js ≥ 18 is installed: `node --version`
+- Check port 3000 is available: `netstat -ano | findstr :3000` (Windows) or `lsof -i :3000` (macOS/Linux)
+- Set a different port: `$env:SERVER_PORT = 3001; node .github/webapp/server.js`
+
+### Web UI shows "Server unreachable"
+- Verify the server is still running in your terminal.
+- Check the terminal for error messages.
+- The UI retries automatically — wait a few seconds.
+
+### Decisions not saving
+- Check that `.github/docs/decisions.md` exists and is writable.
+- Look for error messages in the browser console (F12 → Console tab).
+- The server creates backups before writing — check for `.bak` files if data seems lost.
+
+### Questionnaires not showing up
+- Verify questionnaire files exist in `BusinessDocs/` subdirectories.
+- Check that the server can read the files (correct working directory).
+- Refresh the page — questionnaires are loaded on tab activation.
+
+### Tests fail after pulling updates
+```bash
+cd .github
+npm install          # Update dev dependencies
+npm test             # Re-run tests
+npm run lint         # Check for lint issues
+```
+
+---
+
+## Manual session state recovery
+
+If `session-state.json` is corrupted or in an unexpected state, you can fix it manually:
+
+1. Open `.github/docs/session/session-state.json` in your editor.
+2. Check `status` — set it to the correct state from the state machine table above.
+3. Check `current_agent` and `current_phase` — set them to where you want to resume.
+4. Clear `open_human_escalations` if stale: set to `[]`.
+5. Save the file and start a new Copilot Chat conversation. Type `CONTINUE`.
+
+**To start completely fresh:** Delete `session-state.json` and run your CREATE or AUDIT command again. The Orchestrator creates a new session.
+
+> **Caution:** Deleting `session-state.json` does not delete phase outputs or decisions. Those files remain in `BusinessDocs/`, `.github/docs/synthesis/`, and `.github/docs/decisions/`. A new session will not automatically reuse them unless you run `REFRESH ONBOARDING`.
+
+---
+
+## When to ask for help
+
+If none of the above resolves your issue:
+1. Check the Orchestrator Log (printed in chat) for the most recent action and error.
+2. Check `session-state.json` for the full state.
+3. Open an Issue on the repository with: the status field, the last agent name, and any error messages from the terminal or Copilot Chat.

--- a/.github/skills/00-orchestrator.md
+++ b/.github/skills/00-orchestrator.md
@@ -52,6 +52,7 @@
 | ORC-42 | Scope change history bounds |
 | ORC-43 | Sprint capacity ownership |
 | ORC-44 | HOTFIX + SCOPE CHANGE concurrency |
+| ORC-46 | Immediate session-state initialization on command |
 
 ---
 
@@ -72,7 +73,9 @@ You do NOT perform software analysis yourself. You are a **process controller**,
 ## STRICT PHASE SEQUENCE (ENFORCE AND MONITOR)
 
 ```
-Onboarding Agent → .github/docs/onboarding/onboarding-output.md + .github/docs/session/session-state.json
+Orchestrator receives command → IMMEDIATELY creates .github/docs/session/session-state.json (status: ONBOARDING, current_agent: 25-onboarding-agent) per ORC-46
+  ↓
+Onboarding Agent → .github/docs/onboarding/onboarding-output.md + UPDATES session-state.json (status: ONBOARDING_COMPLETE)
   ↓ [Required: ONBOARDING_COMPLETE — no open ONBOARDING_BLOCKED items]
   ↓ [Questionnaire Agent: load existing answers from BusinessDocs/ → inject as context blocks per phase agent]
 Phase 1 — Requirements & Strategy: Business Analyst → Domain Expert → Sales Strategist → Financial Analyst → Product Manager (34)
@@ -824,8 +827,8 @@ CREATE|AUDIT [DISC1] [DISC2] [project]
 | Scope Change Agent — Critic + Risk FAILED | Return scope-change re-analysis output to relevant phase agents for correction |
 | Scope Change Agent — Sprint Gate Reconciliation ready | Present reconciliation summary to user; wait for approval before releasing REQUEUED tickets back into Sprint Gate |
 | Scope Change Agent — Master Synthesis update complete | Resume normal Sprint Gate cycle for all REQUEUED tickets |
-| `AUDIT [project]` command received | Activate Onboarding Agent (full scope, AUDIT mode); start intake flow; NO Phase 1 before ONBOARDING_COMPLETE |
-| `CREATE [project]` command received | Activate Onboarding Agent (full scope, CREATE mode); start intake flow; NO Phase 1 before ONBOARDING_COMPLETE |
+| `AUDIT [project]` command received | **Create session-state.json immediately per ORC-46** (status: ONBOARDING); activate Onboarding Agent (full scope, AUDIT mode); start intake flow; NO Phase 1 before ONBOARDING_COMPLETE |
+| `CREATE [project]` command received | **Create session-state.json immediately per ORC-46** (status: ONBOARDING); activate Onboarding Agent (full scope, CREATE mode); start intake flow; NO Phase 1 before ONBOARDING_COMPLETE |
 | `REFRESH ONBOARDING` command received | Activate Onboarding Agent in maintenance mode (steps 3+4 only: scan + tooling check); partially update `.github/docs/onboarding/onboarding-output.md` (intake answers from the original onboarding process remain intact); report ONBOARDING_REFRESHED to active Sprint Gate if running; on conflicts with existing sprint: escalate as `SCOPE_DECISION` |
 | `AUDIT BUSINESS [project]` command received | Store scope `PARTIAL:BUSINESS` in session-state; activate Onboarding Agent (limited scope, AUDIT mode); start Phase 1 agents; activate Synthesis (PARTIAL) after Critic/Risk PASSED |
 | `AUDIT TECH [project]` command received | Store scope `PARTIAL:TECH` in session-state; activate Onboarding Agent (limited scope, AUDIT mode); start Phase 2 agents; activate Synthesis (PARTIAL) after Critic/Risk PASSED |
@@ -922,6 +925,56 @@ Read all `DECIDED` items from the newly activated category file and inject them 
 
 **Exception — SKIP ACTIVATION:**
 If the user explicitly types `SKIP ACTIVATION [category]` before or after auto-activation: write a `DECIDED` item to `.github/docs/decisions.md` documenting the exception: `DEC-[NNN] — Exception: [category] technology introduced without activating deferred decisions. Reason: [user reason].` If the category was already auto-activated, revert it to DEFERRED.
+
+**RULE ORC-46: Immediate Session-State Initialization on Command (MANDATORY)**
+The Orchestrator MUST create `session-state.json` **immediately** upon receiving any CREATE, AUDIT, FEATURE, or SCOPE CHANGE command — BEFORE activating the Onboarding Agent. This ensures:
+1. The web UI pipeline view can display progress from the very first moment
+2. Session recovery (ORC-09) works even if the session crashes mid-onboarding
+3. The `initiated_at` timestamp accurately reflects when the user issued the command
+
+**On command received:**
+1. Parse the command to determine `cycle_type`, `scope`, `project_name`, `mode`, and `project_type` (using the same rules as the Onboarding Agent's scope detection)
+2. Create `.github/docs/session/session-state.json` with:
+   ```json
+   {
+     "schema_version": "1.0",
+     "session_id": "[UUID or timestamp-based ID]",
+     "project_name": "[from command]",
+     "mode": "CREATE | AUDIT",
+     "cycle_type": "[determined from command]",
+     "scope": ["[determined from command]"],
+     "project_type": "greenfield | existing",
+     "feature_name": "string | null",
+     "github_project_name": null,
+     "initiated_at": "[ISO 8601]",
+     "last_updated": "[ISO 8601]",
+     "status": "ONBOARDING",
+     "current_phase": "ONBOARDING",
+     "current_agent": "25-onboarding-agent",
+     "current_step": "Waiting for Onboarding Agent to start",
+     "completed_phases": [],
+     "completed_agents": [],
+     "phase_outputs": { "onboarding": null },
+     "open_human_escalations": [],
+     "insufficient_data_items": [],
+     "questionnaire_answer_summary": {
+       "total_questions": 0,
+       "answered": 0,
+       "open": 0,
+       "coverage_pct": 0,
+       "context_blocks_prepared": []
+     }
+   }
+   ```
+3. Create/update `.github/docs/session/pipeline-progress.json` to reflect the ONBOARDING phase as active
+4. **Then** activate the Onboarding Agent
+
+**The Onboarding Agent's Step 5 updates (not creates) this file** — setting `status: "ONBOARDING_COMPLETE"`, `current_phase: "PHASE-1"`, `current_agent: "01-business-analyst"`, and filling in fields gathered during onboarding (`github_project_name`, `canva_api_token`, etc.).
+
+**Exceptions:**
+- `HOTFIX [description]` — existing session-state is reused; Onboarding Agent is NOT restarted (per ORC-23)
+- `REFRESH ONBOARDING` — existing session-state is reused; only Steps 3+4 run
+- `CONTINUE` — existing session-state is loaded, not created (per ORC-33)
 
 ---
 

--- a/.github/skills/25-onboarding-agent.md
+++ b/.github/skills/25-onboarding-agent.md
@@ -299,27 +299,21 @@ If critical tools are missing: document as `TOOLING_GAP: [name]` — this does N
 
 ---
 
-### Step 5: Initialize Session State
+### Step 5: Finalize Session State
 
-Create the initial session state per `.github/docs/contracts/session-state-contract.md`:
+Update the session state file that was created by the Orchestrator (per ORC-46 in `.github/skills/00-orchestrator.md`). The Orchestrator creates `session-state.json` immediately on command receipt with `status: "ONBOARDING"`. The Onboarding Agent now **updates** it to reflect completion:
+
+Read `.github/docs/session/session-state.json` and update the following fields:
 
 ```json
 {
-  "session_id": "[UUID or timestamp-based ID]",
-  "cycle_type": "FULL_CREATE | PARTIAL_CREATE | COMBO_CREATE | FULL_AUDIT | PARTIAL_AUDIT | COMBO_AUDIT | FEATURE | REEVALUATE | HOTFIX | REFRESH",
-  "project_type": "greenfield | existing | hybrid",
-  "scope": ["BUSINESS", "TECH", "UX", "MARKETING"],
-  "feature_name": null,
   "status": "ONBOARDING_COMPLETE",
   "current_phase": "PHASE-1",
   "current_agent": "01-business-analyst",
+  "current_step": "Waiting for Phase 1 to start",
   "github_project_name": "[filled in by user]",
   "canva_api_token": "[token or empty string on SKIP]",
-  "completed_phases": [],
-  "completed_agents": [],
   "onboarding_output_path": ".github/docs/onboarding/onboarding-output.md",
-  "synthesis_path": null,
-  "sprint_backlog_path": null,
   "last_updated": "[ISO 8601]",
   "open_human_escalations": [],
   "insufficient_data_items": [],
@@ -332,6 +326,8 @@ Create the initial session state per `.github/docs/contracts/session-state-contr
   }
 }
 ```
+
+All other fields (`session_id`, `cycle_type`, `scope`, `project_type`, `mode`, `project_name`, `initiated_at`, etc.) were set by the Orchestrator at command receipt and MUST NOT be overwritten.
 
 **Rules for `cycle_type` and `scope`:**
 | Command | `cycle_type` | `project_type` | `scope` |
@@ -358,7 +354,7 @@ Create the initial session state per `.github/docs/contracts/session-state-contr
 > **`scope` is always in canonical order:** BUSINESS → TECH → UX → MARKETING.
 
 **Scope detection at Onboarding (MANDATORY):**
-Read the typed command before Step 2 and determine the mode and scope:
+Read the typed command before Step 2 and determine the mode and scope. Note: The Orchestrator has already used these same rules to populate `session-state.json` (per ORC-46). Verify that the values in `session-state.json` match your parsing — if they differ, update the file and log `SESSION_STATE_CORRECTED: [field]`.
 1. `CREATE` or `AUDIT` keyword determines the mode (`project_type: greenfield` vs `existing`).
 2. One discipline (`CREATE TECH project`) → `cycle_type: PARTIAL_CREATE`; intake limited to that discipline.
 3. Multiple disciplines (`CREATE TECH UX project`) → `cycle_type: COMBO_CREATE`; combined intake for all specified disciplines.
@@ -367,7 +363,7 @@ Read the typed command before Step 2 and determine the mode and scope:
 6. `HOTFIX [description]` → `cycle_type: HOTFIX`; **Onboarding Agent is NOT restarted** — existing Onboarding Output remains valid; Orchestrator goes directly to Sprint Gate BYPASS (RULE ORC-23).
 7. `REFRESH ONBOARDING` → `cycle_type: REFRESH`; Onboarding Agent runs **only Steps 3 and 4** again (scan + tooling verification); intake answers from Step 2 remain unchanged.
 
-Save to: `.github/docs/session/session-state.json`
+Update: `.github/docs/session/session-state.json` (file already exists — created by Orchestrator per ORC-46)
 
 ---
 
@@ -412,7 +408,7 @@ Both methods write to the same files. After answering, type REEVALUATE to incorp
 - [ ] `GITHUB_PROJECT_NAME` requested from user and saved in session state
 - [ ] Tooling verification performed per tooling-contract.md
 - [ ] TOOLING_GAP items documented (with Phase 5 implication)
-- [ ] Session State created at .github/docs/session/session-state.json
+- [ ] Session State updated at .github/docs/session/session-state.json (status: ONBOARDING_COMPLETE)
 - [ ] Onboarding Output Document present at .github/docs/onboarding/onboarding-output.md
 - [ ] Status: ONBOARDING_COMPLETE — ready for Phase 1
 ```

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -189,6 +189,105 @@ docs: update README with badges and technology stack
 
 ---
 
+## Webapp Development Cookbook
+
+Common recipes for extending the web UI at `.github/webapp/`.
+
+### Adding a New API Endpoint
+
+1. Write your handler function in `server.js` following the existing pattern:
+   ```js
+   function apiGetMyThing(req, res) {
+     // Use store.readFile() / store.writeFileSync() for I/O
+     // Use json(res, 200, data) for responses
+     // Use errorResponse(code, message) for errors
+   }
+   ```
+
+2. Register the route in the `ROUTES` object:
+   ```js
+   const ROUTES = {
+     // ... existing routes
+     'GET /api/my-thing': apiGetMyThing,
+   };
+   ```
+   The router matches `METHOD /path` strings. Method-not-allowed handling is automatic.
+
+3. Add user-facing strings to `strings.js` if the response includes messages.
+
+4. Add error codes to `utils/errors.js` if the endpoint can fail in new ways.
+
+5. Write tests — use `InMemoryStore` (never real filesystem):
+   ```js
+   import { createTestServer } from './server.test-helpers.js';
+   // Or follow the pattern in existing test files
+   ```
+
+### Adding a New Tab to the UI
+
+The UI is a single-page app in `index.html`. Tabs are `<section>` elements shown/hidden with CSS.
+
+1. Add a `<button>` to the tab bar (search for `tab-bar` in index.html):
+   ```html
+   <button class="tab-btn" data-tab="my-tab">My Tab</button>
+   ```
+
+2. Add the content section:
+   ```html
+   <section id="my-tab" class="tab-content" hidden>
+     <!-- Your HTML here -->
+   </section>
+   ```
+
+3. The existing tab-switching JS handles visibility automatically based on `data-tab` matching the section `id`.
+
+4. Fetch data from your API endpoint in a `loadMyTab()` function and call it when the tab activates.
+
+### Adding a New Model Parser
+
+Model parsers live in `models.js`. They transform raw file content into structured data.
+
+1. Export a new function from `models.js`:
+   ```js
+   function parseMyFormat(content) {
+     // Parse the markdown/JSON content
+     // Return structured data
+   }
+   ```
+
+2. Write unit tests in a test file (follow the pattern in `models.test.js`).
+
+3. Use the parser in your API handler via `store.readFile()` + `parseMyFormat()`.
+
+### Adding Validation Schemas
+
+JSON schemas live in `schemas.js`. Used by endpoints that accept POST bodies.
+
+1. Add your schema to `schemas.js`:
+   ```js
+   const myThingSchema = { type: 'object', required: [...], properties: { ... } };
+   ```
+
+2. Validate in your handler:
+   ```js
+   const { valid, errors } = validateSchema(body, myThingSchema);
+   if (!valid) return json(res, 400, errorResponse('VALIDATION_FAILED', errors));
+   ```
+
+### Key Patterns to Follow
+
+| Pattern | Where | Why |
+|---------|-------|-----|
+| Use `store` abstraction | All file I/O | Enables `InMemoryStore` in tests |
+| Use `safeWriteSync()` | All writes | Atomic writes with backup |
+| Use `safePath()` | All user-provided paths | Prevents path traversal |
+| Use `detectSecrets()` | All user input saved to disk | Prevents accidental credential storage |
+| Use `setSecurityHeaders()` | All responses | CSP, X-Frame-Options, etc. |
+| Use `strings.js` | All user-facing text | Externalized for maintainability |
+| Use `utils/errors.js` | All error responses | Consistent error codes |
+
+---
+
 ## Questions?
 
 Open a [GitHub Issue](https://github.com/RobertAgterhuis/myAgentic-IT-Project-team/issues) for questions, bug reports, or feature requests.

--- a/docs/decisions-architecture.md
+++ b/docs/decisions-architecture.md
@@ -1,0 +1,237 @@
+# Decision System — Technical Architecture
+
+> This document describes the internal architecture of the decision system: file layout, data flow, agent interactions, category lifecycle, and enforcement mechanisms. For a user-facing guide, see `.github/help/decisions.md`.
+
+---
+
+## 1. File architecture
+
+### Index file
+
+**Path:** `.github/docs/decisions.md`
+
+The index file serves two purposes:
+
+1. **Open Questions table** — uncategorized items (type `DECIDED` or `OPEN_QUESTION`, status `OPEN`/`DECIDED`/`DEFERRED`/`EXPIRED`).
+2. **Category Registry table** — a lookup table mapping each technology category to its file, decision count, status (`ACTIVE`/`PARTIAL`/`DEFERRED`), and applicability flag.
+
+The index file is the Orchestrator's first read target at every Sprint Gate.
+
+### Category files
+
+**Path:** `.github/docs/decisions/[stack].md`
+
+Each category file groups decisions for one technology stack. File names are lowercase-kebab (e.g. `typescript-eslint.md`, `bicep-iac.md`).
+
+**Header block** (mandatory, lines 1–5):
+
+```markdown
+# [Category Name] Decisions
+
+> Stack: [name] | Status: ACTIVE|PARTIAL|DEFERRED | Applicable: YES|NO
+```
+
+`PARTIAL` files additionally contain a "Deferred Decisions" subsection for individually deferred rows. `DEFERRED` files include a `> Deferred-Reason:` line explaining why.
+
+**Body:** A markdown table with columns `ID | Priority | Scope | Decision | Notes | Date`. Each row is one `DECIDED` item.
+
+### Current categories
+
+| File | Stack | Typical status |
+|------|-------|---------------|
+| `transformation.md` | Transformation patterns | ACTIVE |
+| `reevaluation.md` | Reevaluation rules | ACTIVE |
+| `github-actions.md` | CI/CD with GitHub Actions | ACTIVE or PARTIAL |
+| `typescript-eslint.md` | TypeScript + ESLint config | ACTIVE or PARTIAL |
+| `cross-cutting.md` | Cross-cutting concerns | ACTIVE or PARTIAL |
+| `bicep-iac.md` | Infrastructure as Code (Bicep) | DEFERRED |
+| `azure-devops.md` | Azure DevOps pipelines | DEFERRED |
+| `dotnet.md` | .NET / C# | DEFERRED |
+| `docker.md` | Docker / containers | DEFERRED |
+| `vite.md` | Vite build tooling | DEFERRED |
+| `nextjs.md` | Next.js framework | DEFERRED |
+
+---
+
+## 2. Data flow diagram
+
+```
+                         ┌──────────────────────────────┐
+                         │         Web UI (webapp)       │
+                         │   POST /api/decisions/...     │
+                         └──────────┬───────────────────┘
+                                    │ reads / writes
+                                    ▼
+                    ┌───────────────────────────────┐
+                    │  .github/docs/decisions.md    │  ◄── index file
+                    │  (Open Questions + Registry)  │
+                    └──────────┬────────────────────┘
+                               │ Registry references
+                               ▼
+              ┌────────────────────────────────────┐
+              │  .github/docs/decisions/*.md        │  ◄── category files
+              │  (ACTIVE / PARTIAL / DEFERRED)      │
+              └──────────┬─────────────────────────┘
+                         │
+          ┌──────────────┼──────────────────┐
+          │              │                  │
+          ▼              ▼                  ▼
+   ┌────────────┐ ┌────────────┐   ┌─────────────┐
+   │ Sprint     │ │ Decision   │   │ Phase 5     │
+   │ Gate       │ │ injection  │   │ enforcement │
+   │ (Step 0)   │ │ (Step 5)   │   │ (triple-    │
+   │            │ │            │   │  check)     │
+   └────────────┘ └────────────┘   └─────────────┘
+```
+
+---
+
+## 3. Orchestrator interactions
+
+### 3a. Sprint Gate — Step 0 (decision loading)
+
+Executed before every sprint. Defined in the Orchestrator skill file (RULE ORC-06+).
+
+1. **Read index:** Extract all items from `.github/docs/decisions.md` with status `OPEN` or `DECIDED`.
+2. **Scan category directory:** For each `.md` file in `.github/docs/decisions/`, read the `> Status:` header line.
+   - `DEFERRED` → **skip entirely**.
+   - `ACTIVE` or `PARTIAL` → read all `DECIDED` rows. For `PARTIAL` files, also note individually deferred rows (informational only).
+3. **Filter OPEN HIGH:** Items where `priority = HIGH` and `scope` matches the current sprint or its stories → **block the Sprint Gate**. Present to the user with instructions to answer.
+4. **Filter OPEN MEDIUM/LOW:** List as informational, non-blocking.
+5. **Store constraints:** Aggregate all `DECIDED` items (from index + active categories) into a sprint-scoped constraint set for injection in step 5 of sprint start.
+
+### 3b. Sprint start — Step 5 (decision injection)
+
+After the Sprint Gate passes and the user chooses `IMPLEMENT`:
+
+1. Load all `DECIDED` items from index + ACTIVE/PARTIAL category files.
+2. Skip DEFERRED category files. Skip individually deferred rows within PARTIAL files.
+3. Filter by scope → keep only decisions relevant to the current sprint, its stories, or the active agents.
+4. Inject the filtered set as **hard constraints** into each agent's context block.
+5. Log which decisions (with category source) were injected in the Orchestrator Log.
+
+### 3c. Deferred category auto-activation (ORC-45)
+
+When any agent reports one of these signals:
+- `DEFERRED_TECH_REQUIRED` — Implementation Agent needs the technology before coding.
+- `DEFERRED_TECH_DETECTED` — Test Agent or PR/Review Agent finds deferred tech in code/diff.
+- `DEFERRED_ACTIVATION_REQUIRED` — any other agent.
+
+The Orchestrator executes a six-step activation:
+
+| Step | Action |
+|------|--------|
+| 1 | Open the category file → change `Status: DEFERRED` → `ACTIVE`, `Applicable: NO` → `YES`, remove `Deferred-Reason` line. |
+| 2 | Update the matching row in the index file Category Registry table. |
+| 3 | Append audit trail to the category file: `> Activated: [date] | Trigger: [signal] | Agent: [name] | Story: [SP-ID]`. |
+| 4 | Update `session-state.json` with `category_activated: [file]`. |
+| 5 | Notify user (informational, non-blocking). |
+| 6 | Read all `DECIDED` items from the newly activated file → inject as hard constraints → resume the halted agent. |
+
+**Exception path:** User types `SKIP ACTIVATION [category]` → Orchestrator writes a `DECIDED` exception item to the index file and reverts the category to `DEFERRED` if already activated.
+
+---
+
+## 4. Enforcement chain (Phase 5 triple-check)
+
+Three agents independently validate decision compliance. A violation at any point blocks progress.
+
+### 4a. Implementation Agent (pre-coding)
+
+**Trigger:** Definition of Ready check, before writing any code.
+
+1. Load all `DECIDED` items (index + ACTIVE/PARTIAL categories). Skip DEFERRED.
+2. Every `DECIDED` item is a hard constraint — do not write code that conflicts.
+3. If the story requires a technology matching a DEFERRED category → **HALT**. Report `DEFERRED_TECH_REQUIRED: [category]`. Wait for Orchestrator auto-activation (ORC-45), then resume with newly active constraints.
+4. Document: `DECISIONS_LOADED: [N] — active constraints: [summary]`.
+
+### 4b. Test Agent (post-coding)
+
+**Trigger:** Step 6b of test execution, after functional tests pass.
+
+1. Load decisions (same read pattern: index + ACTIVE/PARTIAL, skip DEFERRED).
+2. Filter by scope overlap with the current story's domain (file types, framework).
+3. Verify each applicable `DECIDED` item against the implementation code.
+4. On violation: `DEC-VIOLATION: [DEC-ID] — [expected vs actual]`. Return to Implementation Agent.
+5. Deferred technology detection: if code introduces files matching a DEFERRED category → `DEFERRED_TECH_DETECTED: [category]`. Escalate to Orchestrator.
+6. Document in Test Report: `DECISION COMPLIANCE: Applicable: [N], Compliant: [N], Violations: [list or NONE]`.
+
+### 4c. PR/Review Agent (pre-merge)
+
+**Trigger:** Step 2g and 2h of PR review.
+
+**Decision compliance (2g):**
+
+1. Load decisions (same pattern).
+2. Scope-match by file extension in the PR diff:
+   - `.js`/`.ts`/`.mjs` → TypeScript/ESLint, Cross-Cutting
+   - `.yml`/`.yaml` in `.github/workflows/` → GitHub Actions
+   - `Dockerfile`, `docker-compose.*` → Docker
+   - `.bicep` → Bicep/IaC
+   - `.cs`/`.csproj` → .NET
+   - All files → Cross-Cutting, Transformation
+3. Verify each applicable decision against the diff.
+4. On violation: `DEC-REVIEW: VIOLATION [DEC-ID]` → return PR, block merge.
+
+**Deferred technology detection (2h):**
+
+| File pattern in diff | DEFERRED category |
+|---------------------|-------------------|
+| `Dockerfile`, `docker-compose.*`, `.dockerignore` | `docker.md` |
+| `*.bicep`, `*.arm.json`, `azuredeploy.*` | `bicep-iac.md` |
+| `*.cs`, `*.csproj`, `*.sln`, `global.json` | `dotnet.md` |
+| `azure-pipelines.yml`, `.azure-devops/` | `azure-devops.md` |
+| `vite.config.*`, `vitest.config.*` | `vite.md` |
+| `next.config.*`, `pages/`, `app/` (Next.js imports) | `nextjs.md` |
+
+On match with a DEFERRED category → block merge → escalate to Orchestrator for auto-activation.
+
+---
+
+## 5. Guardrail references
+
+| Guardrail | File | Scope |
+|-----------|------|-------|
+| **G-GLOB-58** | `.github/docs/guardrails/00-global-guardrails.md` | All Phase 5 agents must validate against `DECIDED` items. Skip DEFERRED for compliance but scan for activation triggers. |
+| **IMPL-GUARD-32** | `.github/docs/guardrails/06-implementation-guardrails.md` | Decision compliance triple-check: Implementation → Test → PR/Review. All three must independently verify. |
+| **IMPL-GUARD-33** | `.github/docs/guardrails/06-implementation-guardrails.md` | HALT before introducing deferred technology. Escalate to Orchestrator for ORC-45 auto-activation. |
+
+---
+
+## 6. Orchestrator rules index
+
+| Rule | Purpose |
+|------|---------|
+| **ORC-45** | Deferred Decision Category Activation (6-step auto-activate + exception path) |
+| **ORC-06** | Backlogged sprints are never activated by the Implementation Agent |
+| **ORC-07** | All-backlog prompt when no queued sprints remain |
+
+---
+
+## 7. Web UI ↔ file synchronization
+
+The web UI (`node .github/webapp/server.js`, port 3000) reads and writes the same markdown files:
+
+| API endpoint | File affected | Operation |
+|-------------|---------------|-----------|
+| `GET /api/decisions` | `decisions.md` + `decisions/*.md` | Parse and return all decisions |
+| `POST /api/decisions` | `decisions.md` | Append new item to Open Questions table |
+| `PUT /api/decisions/:id` | `decisions.md` or `decisions/[cat].md` | Update status, answer, priority, scope |
+| `POST /api/decisions/activate-category` | `decisions/[cat].md` + `decisions.md` | Change DEFERRED → ACTIVE in header + registry |
+
+The Orchestrator reads the same files — changes made via the web UI are picked up at the next Sprint Gate automatically.
+
+---
+
+## 8. Session state integration
+
+`session-state.json` tracks decision-related state:
+
+- `category_activated: [file]` — set by ORC-45 when a deferred category is auto-activated mid-sprint.
+- Sprint constraints are not persisted in session state; they are recomputed at each Sprint Gate from the decision files.
+
+---
+
+## 9. Reevaluate trigger
+
+When the web UI's Decisions tab writes `.github/docs/session/reevaluate-trigger.json` with `status: "PENDING"`, the Orchestrator picks it up at the next Sprint Gate (Step 0) and invokes the Reevaluate Agent per ORC-28. This allows decision changes to trigger a formal re-evaluation cycle.

--- a/docs/file-system-reference.md
+++ b/docs/file-system-reference.md
@@ -1,0 +1,281 @@
+# File System Reference
+
+> Complete map of the repository — what each directory and key file does, which agents write where, and what's safe to modify.
+
+---
+
+## Top-level structure
+
+```
+myAgentic-IT-Project-team/
+├── .github/                    ← System internals (agents, docs, webapp, CI)
+├── BusinessDocs/               ← User-facing project data (briefs, questionnaires, official docs)
+├── docs/                       ← Public documentation (GitHub Pages, manuals)
+├── Workitems/                  ← Feature-specific workspaces (created by FEATURE command)
+├── CONTRIBUTING.md             ← Contribution guidelines
+├── LICENSE                     ← License file
+├── Readme.md                   ← Project README
+└── SECURITY.md                 ← Security policy
+```
+
+---
+
+## `.github/` — System internals
+
+### Agent skill files — `.github/skills/`
+
+| File pattern | Purpose | Modified by |
+|-------------|---------|------------|
+| `00-orchestrator.md` | Orchestrator rules and flow | System maintainers only |
+| `01-business-analyst.md` through `37-scope-change-agent.md` | One skill file per agent (38 total) | System maintainers only |
+
+These files define agent behavior. **Do not modify** unless you're changing the system itself.
+
+### System documentation — `.github/docs/`
+
+| Path | Purpose | Written by | Safe to edit? |
+|------|---------|-----------|---------------|
+| `agent-index.md` | Lookup table for all skills, guardrails, contracts | System maintainers | No |
+| `mode-guide.md` | CREATE vs AUDIT mode guidance | System maintainers | No |
+| `README.md` | Overview of the docs/ structure | System maintainers | No |
+| `analytics-events.json` | Event tracking definitions | System maintainers | No |
+
+### Contracts — `.github/docs/contracts/`
+
+25 contract files defining the input/output format for every agent type. These are **agent-facing specifications** — they tell each agent what to produce and what to expect as input.
+
+Key contracts:
+| File | Defines |
+|------|---------|
+| `session-state-contract.md` | Session state format, lifecycle, state machine |
+| `human-escalation-protocol.md` | How agents ask you questions |
+| `implementation-output-contract.md` | What the Implementation Agent produces |
+| `test-output-contract.md` | Test report format |
+| `pr-review-output-contract.md` | PR review and sprint completion format |
+| `tooling-contract.md` | Required tools and verification |
+
+**Do not modify** contracts unless you're changing agent behavior.
+
+### Guardrails — `.github/docs/guardrails/`
+
+10 guardrail files that define rules agents must follow:
+
+| File | Scope |
+|------|-------|
+| `00-global-guardrails.md` | Universal rules (all agents) |
+| `01-business-guardrails.md` | Phase 1 agents |
+| `02-architecture-guardrails.md` | Phase 2 agents |
+| `03-security-guardrails.md` | Security constraints |
+| `04-ux-guardrails.md` | Phase 3 agents |
+| `05-marketing-guardrails.md` | Phase 4 agents |
+| `06-implementation-guardrails.md` | Phase 5 agents |
+| `07-legal-guardrails.md` | Legal constraints |
+| `08-content-guardrails.md` | Content rules |
+| `09-questionnaire-guardrails.md` | Questionnaire formatting |
+
+**Do not modify** unless you're changing system rules.
+
+### Templates — `.github/docs/templates/`
+
+4 template files used by agents to format their outputs (analysis, recommendations, sprint plan, guardrails). **Do not modify.**
+
+### Playbooks — `.github/docs/playbooks/`
+
+| File | Purpose |
+|------|---------|
+| `software-creation-playbook.md` | Full CREATE mode process |
+| `commercial-software-audit-playbook.md` | AUDIT mode process |
+
+Agent-facing process definitions. **Do not modify** unless changing the system flow.
+
+### Decisions — `.github/docs/decisions.md` + `.github/docs/decisions/`
+
+| Path | Purpose | Written by | Safe to edit? |
+|------|---------|-----------|---------------|
+| `decisions.md` | Index file — open questions + category registry | You + web UI + Orchestrator | **Yes** |
+| `decisions/*.md` | Category files (11 technology stacks) | You + web UI + Orchestrator | **Yes** (header status, decision rows) |
+
+This is your primary communication channel with the agent team. See the [Decisions help file](../.github/help/decisions.md) for details.
+
+### Session state — `.github/docs/session/`
+
+| File | Purpose | Written by | Safe to edit? |
+|------|---------|-----------|---------------|
+| `session-state.json` | Current cycle progress | Orchestrator + Onboarding Agent | **Carefully** (for recovery only) |
+| `command-queue.json` | Queued command from web UI | Web UI Command Center | Transient — auto-consumed |
+| `reevaluate-trigger.json` | Reevaluation trigger from web UI | Web UI Decisions tab | Transient — auto-consumed |
+| `README.md` | Explains the session directory | — | No |
+
+### Brand assets — `.github/docs/brand/`
+
+| File | Purpose | Written by |
+|------|---------|-----------|
+| `brand-guidelines.md` | Color palette, typography, spacing, logo usage | Brand Strategist (Phase 4) + Brand & Assets Agent |
+| `content-style-guide.md` | Tone of voice, writing rules | Content Strategist (Phase 3) |
+| `design-tokens.json` | Machine-readable design tokens | Brand & Assets Agent (Canva or manual) |
+
+Generated after Phase 4. **Safe to review and suggest changes** — changes take effect via the decision system or reevaluation.
+
+### Storybook — `.github/docs/storybook/`
+
+| File | Purpose | Written by |
+|------|---------|-----------|
+| `component-inventory.md` | UI component library + a11y baseline | Storybook Agent |
+
+Generated after Phase 4, before Synthesis.
+
+### Synthesis — `.github/docs/synthesis/`
+
+| File | Purpose | Written by |
+|------|---------|-----------|
+| `final-report-master.md` | Executive summary, heatmap, risk matrix, roadmap | Synthesis Agent |
+| `final-report-business.md` | Business discipline report | Synthesis Agent |
+| `final-report-tech.md` | Tech discipline report | Synthesis Agent |
+| `final-report-ux.md` | UX discipline report | Synthesis Agent |
+| `final-report-marketing.md` | Marketing discipline report | Synthesis Agent |
+| `cross-team-blocker-matrix.md` | All cross-team dependencies | Synthesis Agent |
+
+You must **APPROVE** all 6 before Phase 5 starts. These are read-only after approval.
+
+### Security — `.github/docs/security/`
+
+| File | Purpose | Written by |
+|------|---------|-----------|
+| `security-handoff-context.md` | Security constraints for all Phase 5 agents | Security Architect (Phase 2) |
+| `sprint-[SP-N]-secret-scan.md` | Secret scan results per sprint | PR/Review Agent |
+
+### Audit trail — `.github/docs/audit/`
+
+| File | Purpose |
+|------|---------|
+| `audit-log.jsonl` | Append-only log of all system actions |
+
+Auto-generated. **Do not modify.**
+
+### Retrospectives — `.github/docs/retrospectives/` (created in Phase 5)
+
+| File | Purpose | Written by |
+|------|---------|-----------|
+| `sprint-[SP-N]-retrospective.md` | Per-sprint retrospective (immutable) | Retrospective Agent |
+| `lessons-learned.md` | Cumulative lessons, top-3 injected into next sprint | Retrospective Agent |
+| `velocity-log.json` | Machine-readable velocity data | Retrospective Agent |
+
+### Metrics — `.github/docs/metrics/` (created in Phase 5)
+
+| File | Purpose | Written by |
+|------|---------|-----------|
+| `sprint-[SP-N]-kpi.json` | KPI measurements per sprint | KPI Agent |
+| `kpi-trend.md` | Trend analysis across sprints | KPI Agent |
+
+---
+
+## `BusinessDocs/` — Project data
+
+| Path | Purpose | Written by | Safe to edit? |
+|------|---------|-----------|---------------|
+| `project-brief.md` | Your project requirements (saved from Command Center) | You (via web UI) | **Yes** |
+| `Phase1-Business/` | Phase 1 analysis outputs + questionnaires | Phase 1 agents + Questionnaire Agent | Review only |
+| `Phase2-Tech/` | Phase 2 analysis outputs + questionnaires | Phase 2 agents + Questionnaire Agent | Review only |
+| `Phase3-UX/` | Phase 3 analysis outputs + questionnaires | Phase 3 agents + Questionnaire Agent | Review only |
+| `Phase4-Marketing/` | Phase 4 analysis outputs + questionnaires | Phase 4 agents + Questionnaire Agent | Review only |
+| `OfficialDocuments/` | Consolidated documents (product vision, financial model, etc.) | Questionnaire Agent | Review only |
+| `questionnaire-index.md` | Master index of all questionnaires and answer status | Questionnaire Agent | Answers only |
+
+### Questionnaire structure per phase:
+```
+BusinessDocs/Phase[N]-[Discipline]/
+├── Questionnaires/
+│   ├── [agent-name]-questionnaire.md     ← Questions for you
+│   └── ...
+├── [agent-name]-analysis.md              ← Agent output
+├── [agent-name]-recommendations.md       ← Agent output
+├── [agent-name]-sprintplan.md            ← Agent output
+└── [agent-name]-guardrails.md            ← Agent output
+```
+
+---
+
+## `docs/` — Public documentation
+
+| File | Purpose | Written by | Safe to edit? |
+|------|---------|-----------|---------------|
+| `index.md` | GitHub Pages landing page | System maintainers | Yes |
+| `user-manual.md` | User guide | Documentation Agent (Phase 5) | After sprint |
+| `technical-manual.md` | API reference + architecture | Documentation Agent (Phase 5) | After sprint |
+| `contributing.md` | Developer contribution guide | System maintainers | Yes |
+| `data-dictionary.md` | Data entity catalog | System maintainers | Yes |
+| `brand-guidelines.md` | Public copy of brand guide | Documentation Agent | After sprint |
+| `decisions-architecture.md` | Decision system technical reference | System maintainers | Yes |
+| `file-system-reference.md` | This file | System maintainers | Yes |
+
+---
+
+## `Workitems/` — Feature workspaces (on demand)
+
+Created by the `FEATURE [name]` command. Each feature gets an isolated directory:
+
+```
+Workitems/
+└── [FEATURENAME]/
+    ├── 00-feature-request.md          ← Feature definition
+    ├── Phase1-Business/               ← Mini-cycle outputs
+    ├── Phase2-Tech/
+    ├── Phase3-UX/
+    ├── Phase4-Marketing/
+    └── sprint-plan.md                 ← Feature-specific sprint plan
+```
+
+Feature workspaces have their own sprint IDs and Sprint Gate, independent of the main project cycle.
+
+---
+
+## `.github/webapp/` — Web UI application
+
+| File | Purpose |
+|------|---------|
+| `server.js` | Express server (API + static files) |
+| `mcp-server.js` | MCP server for Copilot integration |
+| `index.html` | Single-page UI (Command Center, Pipeline, Questionnaires, Decisions, Agents) |
+| `frontend-utils.js` | Shared UI utilities |
+| `store.js` | State management |
+| `schemas.js` | Validation schemas |
+| `models.js` | Data models |
+| `audit.js` | Audit logging |
+| `cache.js` | Server-side caching |
+| `strings.js` | UI string constants |
+| `start.ps1` | PowerShell startup script |
+| `utils/` | Utility modules |
+
+### Tests: `.github/tests/` + `.github/webapp/*.test.js`
+
+| Path | Purpose |
+|------|---------|
+| `tests/unit/` | Unit tests |
+| `tests/integration/` | Integration tests |
+| `webapp/*.test.js` | Webapp-specific tests |
+
+Run with: `cd .github && npm test`
+
+---
+
+## CI/CD — `.github/workflows/`
+
+| File | Purpose |
+|------|---------|
+| `ci.yml` | Continuous integration (lint + test) |
+| `release.yml` | Release workflow |
+| `my-agentic-team-board-sync.yml` | GitHub Project board synchronization |
+
+---
+
+## What's safe to delete?
+
+| Path | Safe to delete? | Consequence |
+|------|----------------|-------------|
+| `session-state.json` | Yes | Loses current progress; can start fresh |
+| `command-queue.json` | Yes | Loses queued (unconsumed) command |
+| `reevaluate-trigger.json` | Yes | Cancels pending reevaluation |
+| `BusinessDocs/` contents | With caution | Loses all phase outputs and questionnaire answers |
+| `.github/docs/synthesis/` contents | With caution | Must re-run Synthesis Agent |
+| Anything in `.github/skills/`, `contracts/`, `guardrails/` | **No** | Breaks agent behavior |
+| `session-state-*-archived.json` | Yes | Old session archives, safe to clean up |

--- a/docs/technical-manual.md
+++ b/docs/technical-manual.md
@@ -24,6 +24,7 @@ This manual covers the server architecture, API reference, data model, configura
 8. [Testing](#testing)
 9. [Development Setup](#development-setup)
 10. [Monitoring & Observability](#monitoring--observability)
+11. [Analytics Events Reference](#analytics-events-reference)
 
 ---
 
@@ -389,9 +390,11 @@ Submit UI analytics events.
 }
 ```
 
-**Valid event types:** `page_view`, `tab_switch`, `question_answered`, `decision_created`, `command_queued`, `theme_toggle`, `font_size_change`, `help_opened`, `onboarding_complete`, `onboarding_skip`, `export_triggered`
+**Valid event types:** `page_view`, `tab_switch`, `command_launch`, `questionnaire_save`, `decision_update`, `error_displayed`, `feature_usage`, `session_start`, `session_end`
 
-**Response:** `{ "accepted": 1, "rejected": 0 }`
+See [Analytics Events Reference](#analytics-events-reference) for full details on each event type.
+
+**Response:** `{ "ok": true, "accepted": 1, "rejected": 0 }`
 
 #### GET /api/analytics
 Returns stored analytics events.
@@ -527,12 +530,15 @@ Location: `.github/docs/session/session-state.json`
 ### decisions.md
 Location: `.github/docs/decisions.md`
 
-Markdown file with three main tables:
-- **Open Questions** — items waiting for user answers
-- **Decided Items** — active constraints (subsections: Transformation, Reevaluation, Operational)
-- **Deferred & Expired** — parked or obsolete items
+Markdown file with two main sections:
+- **Open Questions table** — items waiting for user answers
+- **Category Registry table** — lookup table mapping each technology stack to its category file, decision count, status (`ACTIVE`/`PARTIAL`/`DEFERRED`), and applicability flag
+
+Per-technology decisions live in category files under `.github/docs/decisions/[stack].md`. Each category file has a header (`> Stack: … | Status: … | Applicable: …`) and a table of `DECIDED` items.
 
 Each row: `| ID | Priority | Scope | Decision/Question | Notes/Answer | Date |`
+
+> **For the full file architecture, data flow, deferred activation sequence (ORC-45), and triple-check enforcement chain, see [`docs/decisions-architecture.md`](../decisions-architecture.md).**
 
 ### Questionnaires
 Location: `BusinessDocs/Phase[N]-[Discipline]/Questionnaires/*.md`
@@ -754,3 +760,132 @@ The server emits JSON-formatted log lines to stdout:
 ### Audit Trail
 
 All data mutations (questionnaire answers, decision changes) are logged to the append-only audit trail at `.github/docs/audit/audit.jsonl`. Query via `GET /api/audit?limit=100`.
+
+---
+
+## Analytics Events Reference
+
+_Sprint reference: SP-R2-004-008_
+
+### Architecture
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│  Browser (index.html)                                         │
+│                                                               │
+│  trackEvent(name, props) → _analyticsQueue[]                  │
+│       ↓ (batched, every 5 s or 50 events)                     │
+│  flushAnalytics() → POST /api/analytics { events: [...] }    │
+└────────────────────────────┬──────────────────────────────────┘
+                             │
+┌────────────────────────────▼──────────────────────────────────┐
+│  server.js  apiPostAnalytics()                                │
+│                                                               │
+│  1. Validate each event against VALID_ANALYTICS_EVENTS        │
+│  2. Reject unknown event types (counted, not fatal)           │
+│  3. Append valid events to analytics-events.json              │
+│  4. Cap file at 5 000 events (FIFO — oldest trimmed)          │
+└────────────────────────────┬──────────────────────────────────┘
+                             │
+┌────────────────────────────▼──────────────────────────────────┐
+│  .github/docs/analytics-events.json                           │
+│  [{ "event": "…", "properties": {}, "timestamp": "…" }, …]   │
+└───────────────────────────────────────────────────────────────┘
+```
+
+### Server-Side Valid Event Types
+
+The server validates events against a strict allowlist defined in `server.js`:
+
+```js
+const VALID_ANALYTICS_EVENTS = [
+  'page_view', 'tab_switch', 'command_launch', 'questionnaire_save',
+  'decision_update', 'error_displayed', 'feature_usage',
+  'session_start', 'session_end'
+];
+```
+
+Events not in this list are **rejected** (counted in the `rejected` field of the response).
+
+### Event Catalog
+
+| Event | Description | Expected Properties | Source |
+|-------|-------------|---------------------|--------|
+| `page_view` | User viewed a page/section | `{ page: string }` | Client (not yet wired) |
+| `tab_switch` | User switched to a different tab | `{ tab: string }` | Client — `switchTab()` wrapper |
+| `command_launch` | User launched a command from the Command Center | `{ command: string }` | Client (not yet wired) |
+| `questionnaire_save` | User saved questionnaire answers | `{ file: string, count: number }` | Client (not yet wired) |
+| `decision_update` | User created, answered, decided, or deferred a decision | `{ action: string, id: string }` | Client (not yet wired) |
+| `error_displayed` | An error was shown to the user | `{ message: string, endpoint?: string }` | Client (not yet wired) |
+| `feature_usage` | User used a specific feature | `{ feature: string }` | Client (not yet wired) |
+| `session_start` | User session started | `{}` | Client (not yet wired) |
+| `session_end` | User session ended | `{}` | Client (not yet wired) |
+
+### Client-Side Events Currently Emitted
+
+The front-end (`index.html`) fires these events via `trackEvent()`:
+
+| Call Site | Event Name | Properties | Server Accepts? |
+|-----------|-----------|------------|-----------------|
+| Page load | `app_start` | `{ tab }` | **No** — not in allowlist |
+| Tab switch | `tab_switch` | `{ tab }` | Yes |
+| Onboarding finish | `onboarding_complete` | `{ steps_seen }` | **No** — not in allowlist |
+| Onboarding skip | `onboarding_skip` | `{ step }` | **No** — not in allowlist |
+
+> **Note:** Three of the four client-side events (`app_start`, `onboarding_complete`, `onboarding_skip`) are silently rejected by the server because they are not in `VALID_ANALYTICS_EVENTS`. Only `tab_switch` events are actually persisted. This is a known gap — either the server allowlist should be expanded or the client event names should be changed to match.
+
+### Client Integration
+
+**`trackEvent(eventName, properties)`** — Queues an event for batch submission.
+
+```js
+trackEvent('tab_switch', { tab: 'decisions' });
+```
+
+**Batching:** Events queue in `_analyticsQueue` and flush every 5 seconds (`ANALYTICS_FLUSH_MS`) or when 50 events accumulate. Flushes are fire-and-forget — failures are silently dropped (analytics is non-critical).
+
+**Opt-out:** Users can opt out by setting `localStorage.analytics_optout = '1'`. When opted out, `trackEvent()` returns immediately without queuing.
+
+### Storage
+
+| Property | Value |
+|----------|-------|
+| File | `.github/docs/analytics-events.json` |
+| Format | JSON array of event objects |
+| Max events | 5 000 (`ANALYTICS_MAX_EVENTS`) |
+| Overflow | Oldest events trimmed (FIFO) |
+| Write safety | `withFileLock()` + `safeWriteSync()` |
+
+**Event object schema:**
+
+```json
+{
+  "event": "tab_switch",
+  "properties": { "tab": "decisions" },
+  "timestamp": "2026-03-08T12:00:00.000Z"
+}
+```
+
+The `timestamp` is set server-side (not from the client payload) to prevent clock-skew issues.
+
+### Validation
+
+Server-side validation (`validateAnalyticsEvent`):
+1. Event must be a non-null object
+2. `event` field must be in the `VALID_ANALYTICS_EVENTS` allowlist
+3. `properties`, if present, must be an object
+
+Request-level validation:
+- `events` must be a non-empty array with at most 100 items per batch
+- Invalid events are counted in `rejected` but do not fail the entire request — valid events in the same batch are still persisted
+
+### API Quick Reference
+
+```
+POST /api/analytics
+  Body: { "events": [{ "event": "…", "properties": {} }, …] }
+  Response: { "ok": true, "accepted": N, "rejected": N }
+
+GET /api/analytics
+  Response: { "events": [...], "total": N }
+```

--- a/docs/user-manual.md
+++ b/docs/user-manual.md
@@ -113,6 +113,9 @@ Once you've answered the key questions, run `REEVALUATE [scope]` in Copilot Chat
 
 The **Decisions** tab is your direct communication channel with the agent team. Decisions you create here become hard constraints that all agents follow.
 
+> **For the complete decision lifecycle, category system, deferred activation, and Sprint Gate blocking rules, see [`.github/help/decisions.md`](../.github/help/decisions.md).**  
+> **For technical architecture (file layout, data flow, enforcement chain), see [`docs/decisions-architecture.md`](decisions-architecture.md).**
+
 ### Decision Types
 | Status | Meaning |
 |--------|---------|


### PR DESCRIPTION
## Summary

Systematic documentation audit identified 15 gaps (consolidated into 11 items). All addressed:

### New help files (`.github/help/`)
- **sprints.md** — Sprint cycle guide
- **onboarding.md** — Onboarding process guide
- **troubleshooting.md** — Session recovery guide
- **quality-gates.md** — Critic + Risk validation gates
- **advanced-commands.md** — FEATURE, SCOPE CHANGE, HOTFIX deep-dive
- **synthesis.md** — Final reports, Brand & Storybook agents
- **glossary.md** — 70+ term alphabetical reference

### New docs
- **docs/file-system-reference.md** — Repository directory map
- **docs/decisions-architecture.md** — Decision system technical reference

### Expanded docs
- **docs/technical-manual.md** — Analytics events reference section + fixed incorrect event types in API docs
- **docs/contributing.md** — Webapp development cookbook (5 recipes)
- **.github/help/questionnaires.md** — Reevaluation workflow section
- **.github/help/decisions.md** — Rewritten as comprehensive functional guide

### Bug fixes
- **ORC-46** — session-state.json now created immediately on command (5 files changed)

### Cleanup
- Removed stray root-level `node_modules/` (was in .gitignore, never committed)